### PR TITLE
2.3.2 because 2.3.0 is already used

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-global",
-  "version": "2.3.0",
+  "version": "2.3.2",
   "description": "Lib for expanding functionality and deduplicating code between services",
   "main": "compiled/index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Publish failed.

Somehow 2.3.0 and 2.3.1 are already published: https://www.npmjs.com/package/@luxuryescapes/lib-global

Use 2.3.2