### PR TITLE
fix(taxes) default to per night instead of per stay

### DIFF
--- a/compiled/offer/pricing.js
+++ b/compiled/offer/pricing.js
@@ -15,14 +15,15 @@ var getTaxTotal = function getTaxTotal(_ref) {
   var members = perPerson ? countOfMembers(occupancies) : 1;
   var total = value * members;
 
-  if (type === 'night') {
+  if (type !== 'stay') {
+    // Default to nightly tax
     total = total * nights;
   }
 
   return total;
 };
 /**
- * Extract and validate the offer and offer package for an order
+ * Calculate the taxes included into the total amount for an offer/order
  *
  * interface TaxesAndFees {
  *   name: string;
@@ -41,7 +42,7 @@ var getTaxTotal = function getTaxTotal(_ref) {
  *
  * @param {object} params - All params
  * @param {number} params.total - The total amount of booking period
- * @param {Array<TaxesAndFees>} params.taxesAndFees - The orders currency code
+ * @param {Array<TaxesAndFees>} params.taxesAndFees - The list of taxes
  * @param {number} params.nights - The number of nights
  * @param {Array<Occupants>} params.occupancies - The occupancies
  * @returns {number} Sum of taxes and fees

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-global",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Lib for expanding functionality and deduplicating code between services",
   "main": "compiled/index.js",
   "types": "index.d.ts",

--- a/src/offer/pricing.js
+++ b/src/offer/pricing.js
@@ -8,7 +8,7 @@ const getTaxTotal = ({ type, value, nights, perPerson, occupancies }) => {
   const members = perPerson ? countOfMembers(occupancies) : 1
   let total = value * members
 
-  if (type === 'night') {
+  if (type !== 'stay') { // Default to nightly tax
     total = total * nights
   }
 

--- a/test/offer/pricing.test.js
+++ b/test/offer/pricing.test.js
@@ -6,6 +6,14 @@ const { calculateTaxAmount } = offerLib.pricing
 
 describe('calculateTaxAmount', () => {
   const tests = {
+    'default types are amount, per stay and per group (not per person)': {
+      params: {
+        total: 100,
+        taxesAndFees: [{ name: 'Tax1', value: 10 }],
+        nights: 3,
+      },
+      expected: 30,
+    },
     'percentage per night for a single night': {
       params: {
         total: 100,


### PR DESCRIPTION
Adds a fix for the handling of default values which was accidentally changed with the tax calculation fixes