### PR TITLE
Allow calculated total for each tax

### DIFF
--- a/compiled/offer/pricing.js
+++ b/compiled/offer/pricing.js
@@ -93,6 +93,17 @@ var calculateTaxAmount = function calculateTaxAmount(_ref2) {
 
   return 0;
 };
+/**
+ * Calculate the taxes total amount and inject total of each tax
+ *
+ * @param {object} params - All params
+ * @param {number} params.total - The total amount of booking period
+ * @param {Array<TaxesAndFees>} params.taxesAndFees - The list of taxes
+ * @param {number} params.nights - The number of nights
+ * @param {Array<Occupants>} params.occupancies - The occupancies
+ * @returns Sum of taxes and fees taxesAndFeesTotal and taxesAndFees with total injected taxesAndFeesWithTotalForEach
+ */
+
 
 var calculateAmountForEachTax = function calculateAmountForEachTax(_ref3) {
   var total = _ref3.total,

--- a/compiled/offer/pricing.js
+++ b/compiled/offer/pricing.js
@@ -1,5 +1,29 @@
 "use strict";
 
+var _excluded = ["percentage"];
+
+function _objectWithoutProperties(source, excluded) { if (source == null) return {}; var target = _objectWithoutPropertiesLoose(source, excluded); var key, i; if (Object.getOwnPropertySymbols) { var sourceSymbolKeys = Object.getOwnPropertySymbols(source); for (i = 0; i < sourceSymbolKeys.length; i++) { key = sourceSymbolKeys[i]; if (excluded.indexOf(key) >= 0) continue; if (!Object.prototype.propertyIsEnumerable.call(source, key)) continue; target[key] = source[key]; } } return target; }
+
+function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } return target; }
+
+function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _unsupportedIterableToArray(arr) || _nonIterableSpread(); }
+
+function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+
+function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter); }
+
+function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) return _arrayLikeToArray(arr); }
+
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) { symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); } keys.push.apply(keys, symbols); } return keys; }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 var countOfMembers = function countOfMembers(occupancies) {
   return (occupancies || []).reduce(function (acc, occupancy) {
     return acc + occupancy.adults + (occupancy.children || 0) + (occupancy.infants || 0);
@@ -56,48 +80,91 @@ var calculateTaxAmount = function calculateTaxAmount(_ref2) {
       occupancies = _ref2.occupancies;
 
   if (taxesAndFees && total) {
-    // Group the taxes by unit
-    var groupedTaxes = taxesAndFees.reduce(function (acc, tax) {
-      if (tax.unit === 'percentage') {
-        acc.percentage.push(tax);
-      } else {
-        acc.amount.push(tax);
-      }
+    var _calculateAmountForEa = calculateAmountForEachTax({
+      total: total,
+      taxesAndFees: taxesAndFees,
+      nights: nights,
+      occupancies: occupancies
+    }),
+        taxesAndFeesTotal = _calculateAmountForEa.taxesAndFeesTotal;
 
-      return acc;
-    }, {
-      amount: [],
-      percentage: []
-    }); // Calculate the amount taxes
-
-    var amountTaxes = groupedTaxes.amount.reduce(function (acc, tax) {
-      return acc + getTaxTotal({
-        type: tax.type,
-        value: tax.value,
-        nights: nights,
-        perPerson: tax.per_person,
-        occupancies: occupancies
-      });
-    }, 0); // Calculate the percentage taxes
-
-    var totalExcludingAmountTaxes = total - amountTaxes;
-    var totalTaxPercentage = groupedTaxes.percentage.reduce(function (acc, tax) {
-      return acc + getTaxTotal({
-        type: tax.type,
-        value: tax.value,
-        nights: nights,
-        perPerson: tax.per_person,
-        occupancies: occupancies
-      });
-    }, 0);
-    var percentageTaxes = totalExcludingAmountTaxes - totalExcludingAmountTaxes / (totalTaxPercentage / 100 + 1); // Sum the taxes
-
-    return Math.floor(amountTaxes + percentageTaxes);
+    return taxesAndFeesTotal;
   }
 
   return 0;
 };
 
+var calculateAmountForEachTax = function calculateAmountForEachTax(_ref3) {
+  var total = _ref3.total,
+      taxesAndFees = _ref3.taxesAndFees,
+      nights = _ref3.nights,
+      occupancies = _ref3.occupancies;
+  var taxesAndFeesWithTotalForEach = [];
+  var percentageTaxesAndFees = []; // Group the taxes by unit
+
+  var groupedTaxes = taxesAndFees.reduce(function (acc, tax) {
+    if (tax.unit === 'percentage') {
+      acc.percentage.push(tax);
+    } else {
+      acc.amount.push(tax);
+    }
+
+    return acc;
+  }, {
+    amount: [],
+    percentage: []
+  }); // Calculate the amount taxes
+
+  var amountTaxes = groupedTaxes.amount.reduce(function (acc, tax) {
+    var taxAmount = getTaxTotal({
+      type: tax.type,
+      value: tax.value,
+      nights: nights,
+      perPerson: tax.per_person,
+      occupancies: occupancies
+    }); // Include total for each taxesAndFees
+
+    taxesAndFeesWithTotalForEach.push(_objectSpread(_objectSpread({}, tax), {}, {
+      total: taxAmount
+    }));
+    return acc + taxAmount;
+  }, 0); // Calculate the percentage taxes
+
+  var totalExcludingAmountTaxes = total - amountTaxes;
+  var totalTaxPercentage = groupedTaxes.percentage.reduce(function (acc, tax) {
+    var taxPercent = getTaxTotal({
+      type: tax.type,
+      value: tax.value,
+      nights: nights,
+      perPerson: tax.per_person,
+      occupancies: occupancies
+    });
+    percentageTaxesAndFees.push(_objectSpread(_objectSpread({}, tax), {}, {
+      percentage: taxPercent
+    }));
+    return acc + taxPercent;
+  }, 0);
+  var percentageTaxes = totalExcludingAmountTaxes - totalExcludingAmountTaxes / (totalTaxPercentage / 100 + 1); // Include taxesAndFees with total calculated for percentage taxesAndFees
+
+  if (percentageTaxesAndFees.length > 0) {
+    taxesAndFeesWithTotalForEach = [].concat(_toConsumableArray(taxesAndFeesWithTotalForEach), _toConsumableArray(percentageTaxesAndFees.map(function (_ref4) {
+      var percentage = _ref4.percentage,
+          taxDetails = _objectWithoutProperties(_ref4, _excluded);
+
+      return _objectSpread(_objectSpread({}, taxDetails), {}, {
+        total: percentageTaxes * (percentage / totalTaxPercentage)
+      });
+    })));
+  }
+
+  return {
+    // Sum the taxes
+    taxesAndFeesTotal: Math.floor(amountTaxes + percentageTaxes),
+    taxesAndFeesWithTotalForEach: taxesAndFeesWithTotalForEach
+  };
+};
+
 module.exports = {
-  calculateTaxAmount: calculateTaxAmount
+  calculateTaxAmount: calculateTaxAmount,
+  calculateAmountForEachTax: calculateAmountForEachTax
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-global",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Lib for expanding functionality and deduplicating code between services",
   "main": "compiled/index.js",
   "types": "index.d.ts",

--- a/src/offer/pricing.js
+++ b/src/offer/pricing.js
@@ -63,6 +63,16 @@ const calculateTaxAmount = ({ total, taxesAndFees, nights, occupancies }) => {
   return 0
 }
 
+/**
+ * Calculate the taxes total amount and inject total of each tax
+ *
+ * @param {object} params - All params
+ * @param {number} params.total - The total amount of booking period
+ * @param {Array<TaxesAndFees>} params.taxesAndFees - The list of taxes
+ * @param {number} params.nights - The number of nights
+ * @param {Array<Occupants>} params.occupancies - The occupancies
+ * @returns Sum of taxes and fees (taxesAndFeesTotal) and taxesAndFees with total injected (taxesAndFeesWithTotalForEach)
+ */
 const calculateAmountForEachTax = ({
   total,
   taxesAndFees,

--- a/src/offer/pricing.js
+++ b/src/offer/pricing.js
@@ -140,6 +140,7 @@ const calculateAmountForEachTax = ({
   return {
     // Sum the taxes
     taxesAndFeesTotal: Math.floor(amountTaxes + percentageTaxes),
+    // TaxesAndFees with total for each injected
     taxesAndFeesWithTotalForEach,
   }
 }

--- a/src/offer/pricing.js
+++ b/src/offer/pricing.js
@@ -1,14 +1,22 @@
 const countOfMembers = (occupancies) => {
-  return (occupancies || []).reduce((acc, occupancy) => {
-    return acc + occupancy.adults + (occupancy.children || 0) + (occupancy.infants || 0)
-  }, 0) || 2
+  return (
+    (occupancies || []).reduce((acc, occupancy) => {
+      return (
+        acc +
+        occupancy.adults +
+        (occupancy.children || 0) +
+        (occupancy.infants || 0)
+      )
+    }, 0) || 2
+  )
 }
 
 const getTaxTotal = ({ type, value, nights, perPerson, occupancies }) => {
   const members = perPerson ? countOfMembers(occupancies) : 1
   let total = value * members
 
-  if (type !== 'stay') { // Default to nightly tax
+  if (type !== 'stay') {
+    // Default to nightly tax
     total = total * nights
   }
 
@@ -42,47 +50,91 @@ const getTaxTotal = ({ type, value, nights, perPerson, occupancies }) => {
  */
 const calculateTaxAmount = ({ total, taxesAndFees, nights, occupancies }) => {
   if (taxesAndFees && total) {
-    // Group the taxes by unit
-    const groupedTaxes = taxesAndFees.reduce((acc, tax) => {
+    const { taxesAndFeesTotal } = calculateAmountForEachTax({
+      total,
+      taxesAndFees,
+      nights,
+      occupancies,
+    })
+
+    return taxesAndFeesTotal
+  }
+
+  return 0
+}
+
+const calculateAmountForEachTax = ({
+  total,
+  taxesAndFees,
+  nights,
+  occupancies,
+}) => {
+  let taxesAndFeesWithTotalForEach = []
+  const percentageTaxesAndFees = []
+  // Group the taxes by unit
+  const groupedTaxes = taxesAndFees.reduce(
+    (acc, tax) => {
       if (tax.unit === 'percentage') {
         acc.percentage.push(tax)
       } else {
         acc.amount.push(tax)
       }
       return acc
-    }, { amount: [], percentage: [] })
+    },
+    { amount: [], percentage: [] },
+  )
 
-    // Calculate the amount taxes
-    const amountTaxes = groupedTaxes.amount.reduce((acc, tax) => {
-      return acc + getTaxTotal({
-        type: tax.type,
-        value: tax.value,
-        nights,
-        perPerson: tax.per_person,
-        occupancies,
-      })
-    }, 0)
+  // Calculate the amount taxes
+  const amountTaxes = groupedTaxes.amount.reduce((acc, tax) => {
+    const taxAmount = getTaxTotal({
+      type: tax.type,
+      value: tax.value,
+      nights,
+      perPerson: tax.per_person,
+      occupancies,
+    })
 
-    // Calculate the percentage taxes
-    const totalExcludingAmountTaxes = total - amountTaxes
-    const totalTaxPercentage = groupedTaxes.percentage.reduce((acc, tax) => {
-      return acc + getTaxTotal({
-        type: tax.type,
-        value: tax.value,
-        nights,
-        perPerson: tax.per_person,
-        occupancies,
-      })
-    }, 0)
-    const percentageTaxes = totalExcludingAmountTaxes - (totalExcludingAmountTaxes / ((totalTaxPercentage / 100) + 1))
+    // Include total for each taxesAndFees
+    taxesAndFeesWithTotalForEach.push({ ...tax, total: taxAmount })
+    return acc + taxAmount
+  }, 0)
 
-    // Sum the taxes
-    return Math.floor(amountTaxes + percentageTaxes)
+  // Calculate the percentage taxes
+  const totalExcludingAmountTaxes = total - amountTaxes
+  const totalTaxPercentage = groupedTaxes.percentage.reduce((acc, tax) => {
+    const taxPercent = getTaxTotal({
+      type: tax.type,
+      value: tax.value,
+      nights,
+      perPerson: tax.per_person,
+      occupancies,
+    })
+    percentageTaxesAndFees.push({ ...tax, percentage: taxPercent })
+    return acc + taxPercent
+  }, 0)
+  const percentageTaxes =
+    totalExcludingAmountTaxes -
+    totalExcludingAmountTaxes / (totalTaxPercentage / 100 + 1)
+
+  // Include taxesAndFees with total calculated for percentage taxesAndFees
+  if (percentageTaxesAndFees.length > 0) {
+    taxesAndFeesWithTotalForEach = [
+      ...taxesAndFeesWithTotalForEach,
+      ...percentageTaxesAndFees.map(({ percentage, ...taxDetails }) => ({
+        ...taxDetails,
+        total: percentageTaxes * (percentage / totalTaxPercentage),
+      })),
+    ]
   }
 
-  return 0
+  return {
+    // Sum the taxes
+    taxesAndFeesTotal: Math.floor(amountTaxes + percentageTaxes),
+    taxesAndFeesWithTotalForEach,
+  }
 }
 
 module.exports = {
   calculateTaxAmount,
+  calculateAmountForEachTax,
 }

--- a/test/offer/pricing.test.js
+++ b/test/offer/pricing.test.js
@@ -2,9 +2,9 @@ const expect = require('chai').expect
 
 const { offer: offerLib } = require('../../compiled')
 
-const { calculateTaxAmount } = offerLib.pricing
+const { calculateTaxAmount, calculateAmountForEachTax } = offerLib.pricing
 
-describe('calculateTaxAmount', () => {
+describe('calculateAmountForEachTax', () => {
   const tests = {
     'default types are amount, per stay and per group (not per person)': {
       params: {
@@ -12,7 +12,16 @@ describe('calculateTaxAmount', () => {
         taxesAndFees: [{ name: 'Tax1', value: 10 }],
         nights: 3,
       },
-      expected: 30,
+      expected: {
+        taxesAndFeesTotal: 30,
+        taxesAndFeesWithTotalForEach: [
+           {
+               name: "Tax1",
+               total: 30,
+               value: 10,
+             }
+        ]
+      },
     },
     'percentage per night for a single night': {
       params: {
@@ -20,7 +29,19 @@ describe('calculateTaxAmount', () => {
         taxesAndFees: [{ name: 'Tax1', unit: 'percentage', type: 'night', per_person: false, value: 20 }],
         nights: 1,
       },
-      expected: 16,
+      expected: {
+        taxesAndFeesTotal: 16,
+        taxesAndFeesWithTotalForEach: [
+           {
+               name: "Tax1",
+               per_person: false,
+               total: 16.666666666666657,
+               type: "night",
+               unit: "percentage",
+               value: 20,
+             }
+        ]
+      },
     },
     'percentage per night for two nights': {
       params: {
@@ -28,7 +49,19 @@ describe('calculateTaxAmount', () => {
         taxesAndFees: [{ name: 'Tax1', unit: 'percentage', type: 'night', per_person: false, value: 10 }],
         nights: 2,
       },
-      expected: 16,
+      expected: {
+        taxesAndFeesTotal: 16,
+        taxesAndFeesWithTotalForEach: [
+            {
+                name: "Tax1",
+                per_person: false,
+                total: 16.666666666666657,
+                type: "night",
+                unit: "percentage",
+                value: 10,
+              }
+        ]
+      },
     },
     'percentage per night for seven nights': {
       params: {
@@ -36,7 +69,19 @@ describe('calculateTaxAmount', () => {
         taxesAndFees: [{ name: 'Tax1', unit: 'percentage', type: 'night', per_person: false, value: 5 }],
         nights: 7,
       },
-      expected: 51,
+      expected: {
+        taxesAndFeesTotal: 51,
+        taxesAndFeesWithTotalForEach: [
+           {
+               name: "Tax1",
+               per_person: false,
+               total: 51.85185185185185,
+               type: "night",
+               unit: "percentage",
+               value: 5,
+             }
+        ]
+      },
     },
     'percentage per stay for a single night': {
       params: {
@@ -44,7 +89,19 @@ describe('calculateTaxAmount', () => {
         taxesAndFees: [{ name: 'Tax1', unit: 'percentage', type: 'stay', per_person: false, value: 20 }],
         nights: 1,
       },
-      expected: 16,
+      expected: {
+        taxesAndFeesTotal: 16,
+        taxesAndFeesWithTotalForEach: [
+            {
+                name: "Tax1",
+                per_person: false,
+                total: 16.666666666666657,
+                type: "stay",
+                unit: "percentage",
+                value: 20,
+              }
+        ]
+      },
     },
     'percentage per stay for a seven nights': {
       params: {
@@ -52,7 +109,19 @@ describe('calculateTaxAmount', () => {
         taxesAndFees: [{ name: 'Tax1', unit: 'percentage', type: 'stay', per_person: false, value: 20 }],
         nights: 7,
       },
-      expected: 16,
+      expected: {
+        taxesAndFeesTotal: 16,
+        taxesAndFeesWithTotalForEach: [
+           {
+               name: "Tax1",
+               per_person: false,
+               total: 16.666666666666657,
+               type: "stay",
+               unit: "percentage",
+               value: 20,
+             }
+        ]
+      },
     },
     'multiple percentages per night': {
       params: {
@@ -64,7 +133,35 @@ describe('calculateTaxAmount', () => {
         ],
         nights: 3,
       },
-      expected: 52,
+      expected: {
+        taxesAndFeesTotal: 52,
+        taxesAndFeesWithTotalForEach: [
+           {
+               name: "Tax1",
+               per_person: false,
+               total: 17.64705882352941,
+               type: "night",
+               unit: "percentage",
+               value: 4,
+             },
+             {
+               name: "Tax2",
+               per_person: false,
+               total: 30.88235294117647,
+               type: "night",
+               unit: "percentage",
+               value: 7,
+             },
+             {
+               name: "Tax3",
+               per_person: false,
+               total: 4.411764705882352,
+               type: "night",
+               unit: "percentage",
+               value: 1,
+             }
+        ]
+      },
     },
     'multiple percentage per stay': {
       params: {
@@ -76,7 +173,35 @@ describe('calculateTaxAmount', () => {
         ],
         nights: 4,
       },
-      expected: 49,
+      expected: {
+        taxesAndFeesTotal: 49,
+        taxesAndFeesWithTotalForEach: [
+            {
+                name: "Tax1",
+                per_person: false,
+                total: 9.022556390977446,
+                type: "stay",
+                unit: "percentage",
+                value: 6,
+              },
+              {
+                name: "Tax2",
+                per_person: false,
+                total: 33.0827067669173,
+                type: "stay",
+                unit: "percentage",
+                value: 22,
+              },
+              {
+                name: "Tax3",
+                per_person: false,
+                total: 7.518796992481206,
+                type: "stay",
+                unit: "percentage",
+                value: 5,
+              }
+        ]
+      },
     },
     'percentage per night and percentage per stay': {
       params: {
@@ -88,7 +213,35 @@ describe('calculateTaxAmount', () => {
         ],
         nights: 7,
       },
-      expected: 63,
+      expected: {
+        taxesAndFeesTotal: 63,
+        taxesAndFeesWithTotalForEach: [
+            {
+                name: "Tax1",
+                per_person: false,
+                total: 47.619047619047606,
+                type: "night",
+                unit: "percentage",
+                value: 5,
+              },
+              {
+                name: "Tax2",
+                per_person: false,
+                total: 13.605442176870746,
+                type: "stay",
+                unit: "percentage",
+                value: 10,
+              },
+              {
+                name: "Tax2",
+                per_person: false,
+                total: 2.721088435374149,
+                type: "stay",
+                unit: "percentage",
+                value: 2,
+              }
+        ]
+      },
     },
     'amount per night for a single night': {
       params: {
@@ -96,7 +249,20 @@ describe('calculateTaxAmount', () => {
         taxesAndFees: [{ name: 'Tax1', unit: 'amount', type: 'night', per_person: false, value: 10 }],
         nights: 1,
       },
-      expected: 10,
+      expected: {
+        taxesAndFeesTotal: 10,
+        taxesAndFeesWithTotalForEach: [
+            {
+                name: "Tax1",
+                per_person: false,
+                total: 10,
+                type: "night",
+                unit: "amount",
+                value: 10,
+              }
+            ]
+        
+      },
     },
     'amount per night for two nights': {
       params: {
@@ -104,7 +270,19 @@ describe('calculateTaxAmount', () => {
         taxesAndFees: [{ name: 'Tax1', unit: 'amount', type: 'night', per_person: false, value: 17 }],
         nights: 2,
       },
-      expected: 34,
+      expected: {
+        taxesAndFeesTotal: 34,
+        taxesAndFeesWithTotalForEach: [
+           {
+               name: "Tax1",
+               per_person: false,
+               total: 34,
+               type: "night",
+               unit: "amount",
+               value: 17,
+             }
+        ]
+      },
     },
     'amount per night for seven nights': {
       params: {
@@ -112,7 +290,19 @@ describe('calculateTaxAmount', () => {
         taxesAndFees: [{ name: 'Tax1', unit: 'amount', type: 'night', per_person: false, value: 5 }],
         nights: 7,
       },
-      expected: 35,
+      expected: {
+        taxesAndFeesTotal: 35,
+        taxesAndFeesWithTotalForEach: [
+            {
+                name: "Tax1",
+                per_person: false,
+                total: 35,
+                type: "night",
+                unit: "amount",
+                value: 5,
+              }
+        ]
+      },
     },
     'multiple amount per night': {
       params: {
@@ -123,7 +313,27 @@ describe('calculateTaxAmount', () => {
         ],
         nights: 2,
       },
-      expected: 26,
+      expected: {
+        taxesAndFeesTotal: 26,
+        taxesAndFeesWithTotalForEach: [
+            {
+                name: "Tax1",
+                per_person: false,
+                total: 20,
+                type: "night",
+                unit: "amount",
+                value: 10,
+              },
+              {
+                name: "Tax2",
+                per_person: false,
+                total: 6,
+                type: "night",
+                unit: "amount",
+                value: 3,
+              }
+        ]
+      },
     },
     'multiple amount per stay': {
       params: {
@@ -135,7 +345,35 @@ describe('calculateTaxAmount', () => {
         ],
         nights: 5,
       },
-      expected: 67,
+      expected: {
+        taxesAndFeesTotal: 67,
+        taxesAndFeesWithTotalForEach: [
+            {
+                name: "Tax1",
+                per_person: false,
+                total: 20,
+                type: "stay",
+                unit: "amount",
+                value: 20,
+              },
+              {
+                name: "Tax2",
+                per_person: false,
+                total: 41,
+                type: "stay",
+                unit: "amount",
+                value: 41,
+              },
+              {
+                name: "Tax3",
+                per_person: false,
+                total: 6,
+                type: "stay",
+                unit: "amount",
+                value: 6,
+              }
+        ]
+      },
     },
     'amount per night and amount per stay': {
       params: {
@@ -146,7 +384,27 @@ describe('calculateTaxAmount', () => {
         ],
         nights: 5,
       },
-      expected: 82,
+      expected: {
+        taxesAndFeesTotal: 82,
+        taxesAndFeesWithTotalForEach: [
+          {
+              name: "Tax1",
+              per_person: false,
+              total: 75,
+              type: "night",
+              unit: "amount",
+              value: 15,
+            },
+            {
+              name: "Tax2",
+              per_person: false,
+              total: 7,
+              type: "stay",
+              unit: "amount",
+              value: 7,
+            }
+        ]
+      },
     },
     'percentage per night and amount per night': {
       params: {
@@ -157,7 +415,27 @@ describe('calculateTaxAmount', () => {
         ],
         nights: 3,
       },
-      expected: 86,
+      expected: {
+        taxesAndFeesTotal: 86,
+        taxesAndFeesWithTotalForEach: [
+           {
+               name: "Tax2",
+               per_person: false,
+               total: 54,
+               type: "night",
+               unit: "amount",
+               value: 18,
+             },
+             {
+               name: "Tax1",
+               per_person: false,
+               total: 32.086956521739125,
+               type: "night",
+               unit: "percentage",
+               value: 5,
+             }
+        ]
+      },
     },
     'percentage and amount per night & percentage and amount per stay': {
       params: {
@@ -170,7 +448,43 @@ describe('calculateTaxAmount', () => {
         ],
         nights: 4,
       },
-      expected: 369,
+      expected: {
+        taxesAndFeesTotal: 369,
+        taxesAndFeesWithTotalForEach: [
+           {
+               name: "Tax3",
+               per_person: false,
+               total: 80,
+               type: "night",
+               unit: "amount",
+               value: 20,
+             },
+             {
+               name: "Tax4",
+               per_person: false,
+               total: 100,
+               type: "stay",
+               unit: "amount",
+               value: 100,
+             },
+             {
+               name: "Tax1",
+               per_person: false,
+               total: 126.15384615384619,
+               type: "night",
+               unit: "percentage",
+               value: 5,
+             },
+             {
+               name: "Tax2",
+               per_person: false,
+               total: 63.076923076923094,
+               type: "stay",
+               unit: "percentage",
+               value: 10,
+             }
+        ]
+      },
     },
     'percentage per night per person (default persons)': {
       params: {
@@ -178,7 +492,19 @@ describe('calculateTaxAmount', () => {
         taxesAndFees: [{ name: 'Tax1', unit: 'percentage', type: 'night', per_person: true, value: 2 }],
         nights: 5,
       },
-      expected: 16,
+      expected: {
+        taxesAndFeesTotal: 16,
+        taxesAndFeesWithTotalForEach: [
+           {
+               name: "Tax1",
+               per_person: true,
+               total: 16.666666666666657,
+               type: "night",
+               unit: "percentage",
+               value: 2,
+             }
+        ]
+      },
     },
     'percentage per night per person': {
       params: {
@@ -187,7 +513,19 @@ describe('calculateTaxAmount', () => {
         nights: 5,
         occupancies: [{ adults: 2, children: 1, infants: 0 }],
       },
-      expected: 23,
+      expected: {
+        taxesAndFeesTotal: 23,
+        taxesAndFeesWithTotalForEach: [
+           {
+               name: "Tax1",
+               per_person: true,
+               total: 23.07692307692308,
+               type: "night",
+               unit: "percentage",
+               value: 2,
+             }
+        ]
+      },
     },
     'percentage per stay per person': {
       params: {
@@ -196,7 +534,19 @@ describe('calculateTaxAmount', () => {
         nights: 7,
         occupancies: [{ adults: 2, children: 1, infants: 1 }],
       },
-      expected: 28,
+      expected: {
+        taxesAndFeesTotal: 28,
+        taxesAndFeesWithTotalForEach: [
+           {
+               name: "Tax1",
+               per_person: true,
+               total: 28.57142857142857,
+               type: "stay",
+               unit: "percentage",
+               value: 10,
+             }
+        ]
+      },
     },
     'percentage per night and percentage per stay per person': {
       params: {
@@ -209,7 +559,35 @@ describe('calculateTaxAmount', () => {
         nights: 7,
         occupancies: [{ adults: 1, children: 1, infants: 1 }],
       },
-      expected: 59,
+      expected: {
+        taxesAndFeesTotal: 59,
+        taxesAndFeesWithTotalForEach: [
+           {
+               name: "Tax1",
+               per_person: true,
+               total: 29.577464788732385,
+               type: "night",
+               unit: "percentage",
+               value: 1,
+             },
+             {
+               name: "Tax2",
+               per_person: true,
+               total: 21.126760563380277,
+               type: "stay",
+               unit: "percentage",
+               value: 5,
+             },
+             {
+               name: "Tax2",
+               per_person: true,
+               total: 8.45070422535211,
+               type: "stay",
+               unit: "percentage",
+               value: 2,
+             }
+        ]
+      },
     },
     'amount per night per person': {
       params: {
@@ -218,7 +596,19 @@ describe('calculateTaxAmount', () => {
         nights: 7,
         occupancies: [{ adults: 2, children: 0, infants: 0 }],
       },
-      expected: 70,
+      expected: {
+        taxesAndFeesTotal: 70,
+        taxesAndFeesWithTotalForEach: [
+           {
+               name: "Tax1",
+               per_person: true,
+               total: 70,
+               type: "night",
+               unit: "amount",
+               value: 5,
+             }
+        ]
+      },
     },
     'amount per night and amount per stay per person': {
       params: {
@@ -230,7 +620,27 @@ describe('calculateTaxAmount', () => {
         nights: 5,
         occupancies: [{ adults: 2, children: 0, infants: 0 }],
       },
-      expected: 164,
+      expected: {
+        taxesAndFeesTotal: 164,
+        taxesAndFeesWithTotalForEach: [
+           {
+               name: "Tax1",
+               per_person: true,
+               total: 150,
+               type: "night",
+               unit: "amount",
+               value: 15,
+             },
+             {
+               name: "Tax2",
+               per_person: true,
+               total: 14,
+               type: "stay",
+               unit: "amount",
+               value: 7,
+             }
+        ]
+      },
     },
     'percentage per night and amount per night per person': {
       params: {
@@ -242,7 +652,27 @@ describe('calculateTaxAmount', () => {
         nights: 3,
         occupancies: [{ adults: 1, children: 3, infants: 1 }],
       },
-      expected: 196,
+      expected: {
+        taxesAndFeesTotal: 196,
+        taxesAndFeesWithTotalForEach: [
+           {
+               name: "Tax2",
+               per_person: true,
+               total: 150,
+               type: "night",
+               unit: "amount",
+               value: 10,
+             },
+             {
+               name: "Tax1",
+               per_person: true,
+               total: 46.55172413793103,
+               type: "night",
+               unit: "percentage",
+               value: 3,
+             }
+        ]
+      },
     },
     'percentage and amount per night & percentage and amount per stay per person': {
       params: {
@@ -256,7 +686,43 @@ describe('calculateTaxAmount', () => {
         nights: 4,
         occupancies: [{ adults: 3, children: 0, infants: 0 }],
       },
-      expected: 483,
+      expected: {
+        taxesAndFeesTotal: 483,
+        taxesAndFeesWithTotalForEach: [
+           {
+               name: "Tax3",
+               per_person: true,
+               total: 240,
+               type: "night",
+               unit: "amount",
+               value: 20,
+             },
+             {
+               name: "Tax4",
+               per_person: true,
+               total: 120,
+               type: "stay",
+               unit: "amount",
+               value: 40,
+             },
+             {
+               name: "Tax1",
+               per_person: true,
+               total: 61.935483870967744,
+               type: "night",
+               unit: "percentage",
+               value: 1,
+             },
+             {
+               name: "Tax2",
+               per_person: true,
+               total: 61.935483870967744,
+               type: "stay",
+               unit: "percentage",
+               value: 4,
+             }
+        ]
+      },
     },
     'mix of per person & per night & per stay': {
       params: {
@@ -270,15 +736,68 @@ describe('calculateTaxAmount', () => {
         nights: 4,
         occupancies: [{ adults: 3, children: 1, infants: 0 }],
       },
-      expected: 375,
-    },
+      expected: {
+        taxesAndFeesTotal: 375,
+        taxesAndFeesWithTotalForEach: [
+          {
+            name: "Tax3",
+            per_person: false,
+            total: 40,
+            type: "night",
+            unit: "amount",
+            value: 10,
+          },
+          {
+            name: "Tax4",
+            per_person: true,
+            total: 104,
+            type: "stay",
+            unit: "amount",
+            value: 26,
+          },
+          {
+            name: "Tax1",
+            per_person: true,
+            total: 199.9416058394161,
+            type: "night",
+            unit: "percentage",
+            value: 2,
+          },
+          {
+            name: "Tax2",
+            per_person: false,
+            total: 31.240875912408768,
+            type: "stay",
+            unit: "percentage",
+            value: 5,
+          }
+        ]
+      }
+    }
   }
 
   for (const key in tests) {
     const test = tests[key]
     it(`should return tax calculated by ${key}`, () => {
-      const result = calculateTaxAmount(test.params)
-      expect(result).to.equal(test.expected)
+      const result = calculateAmountForEachTax(test.params)
+      expect(result).to.deep.equal(test.expected)
     })
   }
+})
+
+describe('calculateAmountForEachTax', () => {
+    it(`should get correct total`, () => {
+      const result = calculateTaxAmount({
+        total: 1000,
+        taxesAndFees: [
+          { name: 'Tax1', unit: 'percentage', type: 'night', per_person: true, value: 2 },
+          { name: 'Tax2', unit: 'percentage', type: 'stay', per_person: false, value: 5 },
+          { name: 'Tax3', unit: 'amount', type: 'night', per_person: false, value: 10 },
+          { name: 'Tax4', unit: 'amount', type: 'stay', per_person: true, value: 26 },
+        ],
+        nights: 4,
+        occupancies: [{ adults: 3, children: 1, infants: 0 }],
+      })
+      expect(result).to.equal(375)
+    })
 })


### PR DESCRIPTION
We need to allow calculate total for each tax as it's required to calculate non-commissionable tax&fee.
I didn't round the result for each taxAndFee as it's mostly for internal use and calculation so rounding them won't be necessary imo, but can leave it as an option if anyone thinks we should allow that.