### PR TITLE
fix(taxes): fix tax calculations - don't multiply percentage taxes

### DIFF
--- a/compiled/offer/pricing.js
+++ b/compiled/offer/pricing.js
@@ -32,6 +32,7 @@ var countOfMembers = function countOfMembers(occupancies) {
 
 var getTaxTotal = function getTaxTotal(_ref) {
   var type = _ref.type,
+      unit = _ref.unit,
       value = _ref.value,
       nights = _ref.nights,
       perPerson = _ref.perPerson,
@@ -39,7 +40,7 @@ var getTaxTotal = function getTaxTotal(_ref) {
   var members = perPerson ? countOfMembers(occupancies) : 1;
   var total = value * members;
 
-  if (type !== 'stay') {
+  if (type !== 'stay' && unit !== 'percentage') {
     // Default to nightly tax
     total = total * nights;
   }
@@ -129,6 +130,7 @@ var calculateAmountForEachTax = function calculateAmountForEachTax(_ref3) {
   var amountTaxes = groupedTaxes.amount.reduce(function (acc, tax) {
     var taxAmount = getTaxTotal({
       type: tax.type,
+      unit: tax.unit,
       value: tax.value,
       nights: nights,
       perPerson: tax.per_person,
@@ -145,6 +147,7 @@ var calculateAmountForEachTax = function calculateAmountForEachTax(_ref3) {
   var totalTaxPercentage = groupedTaxes.percentage.reduce(function (acc, tax) {
     var taxPercent = getTaxTotal({
       type: tax.type,
+      unit: tax.unit,
       value: tax.value,
       nights: nights,
       perPerson: tax.per_person,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-global",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "description": "Lib for expanding functionality and deduplicating code between services",
   "main": "compiled/index.js",
   "types": "index.d.ts",

--- a/src/offer/pricing.js
+++ b/src/offer/pricing.js
@@ -11,11 +11,11 @@ const countOfMembers = (occupancies) => {
   )
 }
 
-const getTaxTotal = ({ type, value, nights, perPerson, occupancies }) => {
+const getTaxTotal = ({ type, unit, value, nights, perPerson, occupancies }) => {
   const members = perPerson ? countOfMembers(occupancies) : 1
   let total = value * members
 
-  if (type !== 'stay') {
+  if (type !== 'stay' && unit !== 'percentage') {
     // Default to nightly tax
     total = total * nights
   }
@@ -98,6 +98,7 @@ const calculateAmountForEachTax = ({
   const amountTaxes = groupedTaxes.amount.reduce((acc, tax) => {
     const taxAmount = getTaxTotal({
       type: tax.type,
+      unit: tax.unit,
       value: tax.value,
       nights,
       perPerson: tax.per_person,
@@ -114,6 +115,7 @@ const calculateAmountForEachTax = ({
   const totalTaxPercentage = groupedTaxes.percentage.reduce((acc, tax) => {
     const taxPercent = getTaxTotal({
       type: tax.type,
+      unit: tax.unit,
       value: tax.value,
       nights,
       perPerson: tax.per_person,

--- a/test/offer/pricing.test.js
+++ b/test/offer/pricing.test.js
@@ -15,12 +15,12 @@ describe('calculateAmountForEachTax', () => {
       expected: {
         taxesAndFeesTotal: 30,
         taxesAndFeesWithTotalForEach: [
-           {
-               name: "Tax1",
-               total: 30,
-               value: 10,
-             }
-        ]
+          {
+            name: 'Tax1',
+            total: 30,
+            value: 10,
+          },
+        ],
       },
     },
     'percentage per night for a single night': {
@@ -32,15 +32,15 @@ describe('calculateAmountForEachTax', () => {
       expected: {
         taxesAndFeesTotal: 16,
         taxesAndFeesWithTotalForEach: [
-           {
-               name: "Tax1",
-               per_person: false,
-               total: 16.666666666666657,
-               type: "night",
-               unit: "percentage",
-               value: 20,
-             }
-        ]
+          {
+            name: 'Tax1',
+            per_person: false,
+            total: 16.666666666666657,
+            type: 'night',
+            unit: 'percentage',
+            value: 20,
+          },
+        ],
       },
     },
     'percentage per night for two nights': {
@@ -50,17 +50,17 @@ describe('calculateAmountForEachTax', () => {
         nights: 2,
       },
       expected: {
-        taxesAndFeesTotal: 16,
+        taxesAndFeesTotal: 9,
         taxesAndFeesWithTotalForEach: [
-            {
-                name: "Tax1",
-                per_person: false,
-                total: 16.666666666666657,
-                type: "night",
-                unit: "percentage",
-                value: 10,
-              }
-        ]
+          {
+            name: 'Tax1',
+            per_person: false,
+            total: 9.090909090909093,
+            type: 'night',
+            unit: 'percentage',
+            value: 10,
+          },
+        ],
       },
     },
     'percentage per night for seven nights': {
@@ -70,17 +70,17 @@ describe('calculateAmountForEachTax', () => {
         nights: 7,
       },
       expected: {
-        taxesAndFeesTotal: 51,
+        taxesAndFeesTotal: 9,
         taxesAndFeesWithTotalForEach: [
-           {
-               name: "Tax1",
-               per_person: false,
-               total: 51.85185185185185,
-               type: "night",
-               unit: "percentage",
-               value: 5,
-             }
-        ]
+          {
+            name: 'Tax1',
+            per_person: false,
+            total: 9.523809523809518,
+            type: 'night',
+            unit: 'percentage',
+            value: 5,
+          },
+        ],
       },
     },
     'percentage per stay for a single night': {
@@ -92,15 +92,15 @@ describe('calculateAmountForEachTax', () => {
       expected: {
         taxesAndFeesTotal: 16,
         taxesAndFeesWithTotalForEach: [
-            {
-                name: "Tax1",
-                per_person: false,
-                total: 16.666666666666657,
-                type: "stay",
-                unit: "percentage",
-                value: 20,
-              }
-        ]
+          {
+            name: 'Tax1',
+            per_person: false,
+            total: 16.666666666666657,
+            type: 'stay',
+            unit: 'percentage',
+            value: 20,
+          },
+        ],
       },
     },
     'percentage per stay for a seven nights': {
@@ -112,15 +112,15 @@ describe('calculateAmountForEachTax', () => {
       expected: {
         taxesAndFeesTotal: 16,
         taxesAndFeesWithTotalForEach: [
-           {
-               name: "Tax1",
-               per_person: false,
-               total: 16.666666666666657,
-               type: "stay",
-               unit: "percentage",
-               value: 20,
-             }
-        ]
+          {
+            name: 'Tax1',
+            per_person: false,
+            total: 16.666666666666657,
+            type: 'stay',
+            unit: 'percentage',
+            value: 20,
+          },
+        ],
       },
     },
     'multiple percentages per night': {
@@ -134,33 +134,33 @@ describe('calculateAmountForEachTax', () => {
         nights: 3,
       },
       expected: {
-        taxesAndFeesTotal: 52,
+        taxesAndFeesTotal: 21,
         taxesAndFeesWithTotalForEach: [
-           {
-               name: "Tax1",
-               per_person: false,
-               total: 17.64705882352941,
-               type: "night",
-               unit: "percentage",
-               value: 4,
-             },
-             {
-               name: "Tax2",
-               per_person: false,
-               total: 30.88235294117647,
-               type: "night",
-               unit: "percentage",
-               value: 7,
-             },
-             {
-               name: "Tax3",
-               per_person: false,
-               total: 4.411764705882352,
-               type: "night",
-               unit: "percentage",
-               value: 1,
-             }
-        ]
+          {
+            name: 'Tax1',
+            per_person: false,
+            total: 7.142857142857148,
+            type: 'night',
+            unit: 'percentage',
+            value: 4,
+          },
+          {
+            name: 'Tax2',
+            per_person: false,
+            total: 12.50000000000001,
+            type: 'night',
+            unit: 'percentage',
+            value: 7,
+          },
+          {
+            name: 'Tax3',
+            per_person: false,
+            total: 1.785714285714287,
+            type: 'night',
+            unit: 'percentage',
+            value: 1,
+          },
+        ],
       },
     },
     'multiple percentage per stay': {
@@ -176,31 +176,31 @@ describe('calculateAmountForEachTax', () => {
       expected: {
         taxesAndFeesTotal: 49,
         taxesAndFeesWithTotalForEach: [
-            {
-                name: "Tax1",
-                per_person: false,
-                total: 9.022556390977446,
-                type: "stay",
-                unit: "percentage",
-                value: 6,
-              },
-              {
-                name: "Tax2",
-                per_person: false,
-                total: 33.0827067669173,
-                type: "stay",
-                unit: "percentage",
-                value: 22,
-              },
-              {
-                name: "Tax3",
-                per_person: false,
-                total: 7.518796992481206,
-                type: "stay",
-                unit: "percentage",
-                value: 5,
-              }
-        ]
+          {
+            name: 'Tax1',
+            per_person: false,
+            total: 9.022556390977446,
+            type: 'stay',
+            unit: 'percentage',
+            value: 6,
+          },
+          {
+            name: 'Tax2',
+            per_person: false,
+            total: 33.0827067669173,
+            type: 'stay',
+            unit: 'percentage',
+            value: 22,
+          },
+          {
+            name: 'Tax3',
+            per_person: false,
+            total: 7.518796992481206,
+            type: 'stay',
+            unit: 'percentage',
+            value: 5,
+          },
+        ],
       },
     },
     'percentage per night and percentage per stay': {
@@ -209,38 +209,38 @@ describe('calculateAmountForEachTax', () => {
         taxesAndFees: [
           { name: 'Tax1', unit: 'percentage', type: 'night', per_person: false, value: 5 },
           { name: 'Tax2', unit: 'percentage', type: 'stay', per_person: false, value: 10 },
-          { name: 'Tax2', unit: 'percentage', type: 'stay', per_person: false, value: 2 },
+          { name: 'Tax3', unit: 'percentage', type: 'stay', per_person: false, value: 2 },
         ],
         nights: 7,
       },
       expected: {
-        taxesAndFeesTotal: 63,
+        taxesAndFeesTotal: 29,
         taxesAndFeesWithTotalForEach: [
-            {
-                name: "Tax1",
-                per_person: false,
-                total: 47.619047619047606,
-                type: "night",
-                unit: "percentage",
-                value: 5,
-              },
-              {
-                name: "Tax2",
-                per_person: false,
-                total: 13.605442176870746,
-                type: "stay",
-                unit: "percentage",
-                value: 10,
-              },
-              {
-                name: "Tax2",
-                per_person: false,
-                total: 2.721088435374149,
-                type: "stay",
-                unit: "percentage",
-                value: 2,
-              }
-        ]
+          {
+            name: 'Tax1',
+            per_person: false,
+            total: 8.547008547008542,
+            type: 'night',
+            unit: 'percentage',
+            value: 5,
+          },
+          {
+            name: 'Tax2',
+            per_person: false,
+            total: 17.094017094017083,
+            type: 'stay',
+            unit: 'percentage',
+            value: 10,
+          },
+          {
+            name: 'Tax3',
+            per_person: false,
+            total: 3.4188034188034164,
+            type: 'stay',
+            unit: 'percentage',
+            value: 2,
+          },
+        ],
       },
     },
     'amount per night for a single night': {
@@ -252,16 +252,16 @@ describe('calculateAmountForEachTax', () => {
       expected: {
         taxesAndFeesTotal: 10,
         taxesAndFeesWithTotalForEach: [
-            {
-                name: "Tax1",
-                per_person: false,
-                total: 10,
-                type: "night",
-                unit: "amount",
-                value: 10,
-              }
-            ]
-        
+          {
+            name: 'Tax1',
+            per_person: false,
+            total: 10,
+            type: 'night',
+            unit: 'amount',
+            value: 10,
+          },
+        ],
+
       },
     },
     'amount per night for two nights': {
@@ -273,15 +273,15 @@ describe('calculateAmountForEachTax', () => {
       expected: {
         taxesAndFeesTotal: 34,
         taxesAndFeesWithTotalForEach: [
-           {
-               name: "Tax1",
-               per_person: false,
-               total: 34,
-               type: "night",
-               unit: "amount",
-               value: 17,
-             }
-        ]
+          {
+            name: 'Tax1',
+            per_person: false,
+            total: 34,
+            type: 'night',
+            unit: 'amount',
+            value: 17,
+          },
+        ],
       },
     },
     'amount per night for seven nights': {
@@ -293,15 +293,15 @@ describe('calculateAmountForEachTax', () => {
       expected: {
         taxesAndFeesTotal: 35,
         taxesAndFeesWithTotalForEach: [
-            {
-                name: "Tax1",
-                per_person: false,
-                total: 35,
-                type: "night",
-                unit: "amount",
-                value: 5,
-              }
-        ]
+          {
+            name: 'Tax1',
+            per_person: false,
+            total: 35,
+            type: 'night',
+            unit: 'amount',
+            value: 5,
+          },
+        ],
       },
     },
     'multiple amount per night': {
@@ -316,23 +316,23 @@ describe('calculateAmountForEachTax', () => {
       expected: {
         taxesAndFeesTotal: 26,
         taxesAndFeesWithTotalForEach: [
-            {
-                name: "Tax1",
-                per_person: false,
-                total: 20,
-                type: "night",
-                unit: "amount",
-                value: 10,
-              },
-              {
-                name: "Tax2",
-                per_person: false,
-                total: 6,
-                type: "night",
-                unit: "amount",
-                value: 3,
-              }
-        ]
+          {
+            name: 'Tax1',
+            per_person: false,
+            total: 20,
+            type: 'night',
+            unit: 'amount',
+            value: 10,
+          },
+          {
+            name: 'Tax2',
+            per_person: false,
+            total: 6,
+            type: 'night',
+            unit: 'amount',
+            value: 3,
+          },
+        ],
       },
     },
     'multiple amount per stay': {
@@ -348,31 +348,31 @@ describe('calculateAmountForEachTax', () => {
       expected: {
         taxesAndFeesTotal: 67,
         taxesAndFeesWithTotalForEach: [
-            {
-                name: "Tax1",
-                per_person: false,
-                total: 20,
-                type: "stay",
-                unit: "amount",
-                value: 20,
-              },
-              {
-                name: "Tax2",
-                per_person: false,
-                total: 41,
-                type: "stay",
-                unit: "amount",
-                value: 41,
-              },
-              {
-                name: "Tax3",
-                per_person: false,
-                total: 6,
-                type: "stay",
-                unit: "amount",
-                value: 6,
-              }
-        ]
+          {
+            name: 'Tax1',
+            per_person: false,
+            total: 20,
+            type: 'stay',
+            unit: 'amount',
+            value: 20,
+          },
+          {
+            name: 'Tax2',
+            per_person: false,
+            total: 41,
+            type: 'stay',
+            unit: 'amount',
+            value: 41,
+          },
+          {
+            name: 'Tax3',
+            per_person: false,
+            total: 6,
+            type: 'stay',
+            unit: 'amount',
+            value: 6,
+          },
+        ],
       },
     },
     'amount per night and amount per stay': {
@@ -388,22 +388,22 @@ describe('calculateAmountForEachTax', () => {
         taxesAndFeesTotal: 82,
         taxesAndFeesWithTotalForEach: [
           {
-              name: "Tax1",
-              per_person: false,
-              total: 75,
-              type: "night",
-              unit: "amount",
-              value: 15,
-            },
-            {
-              name: "Tax2",
-              per_person: false,
-              total: 7,
-              type: "stay",
-              unit: "amount",
-              value: 7,
-            }
-        ]
+            name: 'Tax1',
+            per_person: false,
+            total: 75,
+            type: 'night',
+            unit: 'amount',
+            value: 15,
+          },
+          {
+            name: 'Tax2',
+            per_person: false,
+            total: 7,
+            type: 'stay',
+            unit: 'amount',
+            value: 7,
+          },
+        ],
       },
     },
     'percentage per night and amount per night': {
@@ -416,25 +416,25 @@ describe('calculateAmountForEachTax', () => {
         nights: 3,
       },
       expected: {
-        taxesAndFeesTotal: 86,
+        taxesAndFeesTotal: 65,
         taxesAndFeesWithTotalForEach: [
-           {
-               name: "Tax2",
-               per_person: false,
-               total: 54,
-               type: "night",
-               unit: "amount",
-               value: 18,
-             },
-             {
-               name: "Tax1",
-               per_person: false,
-               total: 32.086956521739125,
-               type: "night",
-               unit: "percentage",
-               value: 5,
-             }
-        ]
+          {
+            name: 'Tax2',
+            per_person: false,
+            total: 54,
+            type: 'night',
+            unit: 'amount',
+            value: 18,
+          },
+          {
+            name: 'Tax1',
+            per_person: false,
+            total: 11.714285714285722,
+            type: 'night',
+            unit: 'percentage',
+            value: 5,
+          },
+        ],
       },
     },
     'percentage and amount per night & percentage and amount per stay': {
@@ -449,41 +449,41 @@ describe('calculateAmountForEachTax', () => {
         nights: 4,
       },
       expected: {
-        taxesAndFeesTotal: 369,
+        taxesAndFeesTotal: 286,
         taxesAndFeesWithTotalForEach: [
-           {
-               name: "Tax3",
-               per_person: false,
-               total: 80,
-               type: "night",
-               unit: "amount",
-               value: 20,
-             },
-             {
-               name: "Tax4",
-               per_person: false,
-               total: 100,
-               type: "stay",
-               unit: "amount",
-               value: 100,
-             },
-             {
-               name: "Tax1",
-               per_person: false,
-               total: 126.15384615384619,
-               type: "night",
-               unit: "percentage",
-               value: 5,
-             },
-             {
-               name: "Tax2",
-               per_person: false,
-               total: 63.076923076923094,
-               type: "stay",
-               unit: "percentage",
-               value: 10,
-             }
-        ]
+          {
+            name: 'Tax3',
+            per_person: false,
+            total: 80,
+            type: 'night',
+            unit: 'amount',
+            value: 20,
+          },
+          {
+            name: 'Tax4',
+            per_person: false,
+            total: 100,
+            type: 'stay',
+            unit: 'amount',
+            value: 100,
+          },
+          {
+            name: 'Tax1',
+            per_person: false,
+            total: 35.652173913043455,
+            type: 'night',
+            unit: 'percentage',
+            value: 5,
+          },
+          {
+            name: 'Tax2',
+            per_person: false,
+            total: 71.30434782608691,
+            type: 'stay',
+            unit: 'percentage',
+            value: 10,
+          },
+        ],
       },
     },
     'percentage per night per person (default persons)': {
@@ -493,17 +493,17 @@ describe('calculateAmountForEachTax', () => {
         nights: 5,
       },
       expected: {
-        taxesAndFeesTotal: 16,
+        taxesAndFeesTotal: 3,
         taxesAndFeesWithTotalForEach: [
-           {
-               name: "Tax1",
-               per_person: true,
-               total: 16.666666666666657,
-               type: "night",
-               unit: "percentage",
-               value: 2,
-             }
-        ]
+          {
+            name: 'Tax1',
+            per_person: true,
+            total: 3.846153846153854,
+            type: 'night',
+            unit: 'percentage',
+            value: 2,
+          },
+        ],
       },
     },
     'percentage per night per person': {
@@ -514,17 +514,17 @@ describe('calculateAmountForEachTax', () => {
         occupancies: [{ adults: 2, children: 1, infants: 0 }],
       },
       expected: {
-        taxesAndFeesTotal: 23,
+        taxesAndFeesTotal: 5,
         taxesAndFeesWithTotalForEach: [
-           {
-               name: "Tax1",
-               per_person: true,
-               total: 23.07692307692308,
-               type: "night",
-               unit: "percentage",
-               value: 2,
-             }
-        ]
+          {
+            name: 'Tax1',
+            per_person: true,
+            total: 5.660377358490564,
+            type: 'night',
+            unit: 'percentage',
+            value: 2,
+          },
+        ],
       },
     },
     'percentage per stay per person': {
@@ -537,15 +537,15 @@ describe('calculateAmountForEachTax', () => {
       expected: {
         taxesAndFeesTotal: 28,
         taxesAndFeesWithTotalForEach: [
-           {
-               name: "Tax1",
-               per_person: true,
-               total: 28.57142857142857,
-               type: "stay",
-               unit: "percentage",
-               value: 10,
-             }
-        ]
+          {
+            name: 'Tax1',
+            per_person: true,
+            total: 28.57142857142857,
+            type: 'stay',
+            unit: 'percentage',
+            value: 10,
+          },
+        ],
       },
     },
     'percentage per night and percentage per stay per person': {
@@ -560,33 +560,33 @@ describe('calculateAmountForEachTax', () => {
         occupancies: [{ adults: 1, children: 1, infants: 1 }],
       },
       expected: {
-        taxesAndFeesTotal: 59,
+        taxesAndFeesTotal: 38,
         taxesAndFeesWithTotalForEach: [
-           {
-               name: "Tax1",
-               per_person: true,
-               total: 29.577464788732385,
-               type: "night",
-               unit: "percentage",
-               value: 1,
-             },
-             {
-               name: "Tax2",
-               per_person: true,
-               total: 21.126760563380277,
-               type: "stay",
-               unit: "percentage",
-               value: 5,
-             },
-             {
-               name: "Tax2",
-               per_person: true,
-               total: 8.45070422535211,
-               type: "stay",
-               unit: "percentage",
-               value: 2,
-             }
-        ]
+          {
+            name: 'Tax1',
+            per_person: true,
+            total: 4.838709677419356,
+            type: 'night',
+            unit: 'percentage',
+            value: 1,
+          },
+          {
+            name: 'Tax2',
+            per_person: true,
+            total: 24.19354838709678,
+            type: 'stay',
+            unit: 'percentage',
+            value: 5,
+          },
+          {
+            name: 'Tax2',
+            per_person: true,
+            total: 9.677419354838712,
+            type: 'stay',
+            unit: 'percentage',
+            value: 2,
+          },
+        ],
       },
     },
     'amount per night per person': {
@@ -599,15 +599,15 @@ describe('calculateAmountForEachTax', () => {
       expected: {
         taxesAndFeesTotal: 70,
         taxesAndFeesWithTotalForEach: [
-           {
-               name: "Tax1",
-               per_person: true,
-               total: 70,
-               type: "night",
-               unit: "amount",
-               value: 5,
-             }
-        ]
+          {
+            name: 'Tax1',
+            per_person: true,
+            total: 70,
+            type: 'night',
+            unit: 'amount',
+            value: 5,
+          },
+        ],
       },
     },
     'amount per night and amount per stay per person': {
@@ -623,23 +623,23 @@ describe('calculateAmountForEachTax', () => {
       expected: {
         taxesAndFeesTotal: 164,
         taxesAndFeesWithTotalForEach: [
-           {
-               name: "Tax1",
-               per_person: true,
-               total: 150,
-               type: "night",
-               unit: "amount",
-               value: 15,
-             },
-             {
-               name: "Tax2",
-               per_person: true,
-               total: 14,
-               type: "stay",
-               unit: "amount",
-               value: 7,
-             }
-        ]
+          {
+            name: 'Tax1',
+            per_person: true,
+            total: 150,
+            type: 'night',
+            unit: 'amount',
+            value: 15,
+          },
+          {
+            name: 'Tax2',
+            per_person: true,
+            total: 14,
+            type: 'stay',
+            unit: 'amount',
+            value: 7,
+          },
+        ],
       },
     },
     'percentage per night and amount per night per person': {
@@ -653,25 +653,25 @@ describe('calculateAmountForEachTax', () => {
         occupancies: [{ adults: 1, children: 3, infants: 1 }],
       },
       expected: {
-        taxesAndFeesTotal: 196,
+        taxesAndFeesTotal: 169,
         taxesAndFeesWithTotalForEach: [
-           {
-               name: "Tax2",
-               per_person: true,
-               total: 150,
-               type: "night",
-               unit: "amount",
-               value: 10,
-             },
-             {
-               name: "Tax1",
-               per_person: true,
-               total: 46.55172413793103,
-               type: "night",
-               unit: "percentage",
-               value: 3,
-             }
-        ]
+          {
+            name: 'Tax2',
+            per_person: true,
+            total: 150,
+            type: 'night',
+            unit: 'amount',
+            value: 10,
+          },
+          {
+            name: 'Tax1',
+            per_person: true,
+            total: 19.565217391304344,
+            type: 'night',
+            unit: 'percentage',
+            value: 3,
+          },
+        ],
       },
     },
     'percentage and amount per night & percentage and amount per stay per person': {
@@ -687,41 +687,41 @@ describe('calculateAmountForEachTax', () => {
         occupancies: [{ adults: 3, children: 0, infants: 0 }],
       },
       expected: {
-        taxesAndFeesTotal: 483,
+        taxesAndFeesTotal: 443,
         taxesAndFeesWithTotalForEach: [
-           {
-               name: "Tax3",
-               per_person: true,
-               total: 240,
-               type: "night",
-               unit: "amount",
-               value: 20,
-             },
-             {
-               name: "Tax4",
-               per_person: true,
-               total: 120,
-               type: "stay",
-               unit: "amount",
-               value: 40,
-             },
-             {
-               name: "Tax1",
-               per_person: true,
-               total: 61.935483870967744,
-               type: "night",
-               unit: "percentage",
-               value: 1,
-             },
-             {
-               name: "Tax2",
-               per_person: true,
-               total: 61.935483870967744,
-               type: "stay",
-               unit: "percentage",
-               value: 4,
-             }
-        ]
+          {
+            name: 'Tax3',
+            per_person: true,
+            total: 240,
+            type: 'night',
+            unit: 'amount',
+            value: 20,
+          },
+          {
+            name: 'Tax4',
+            per_person: true,
+            total: 120,
+            type: 'stay',
+            unit: 'amount',
+            value: 40,
+          },
+          {
+            name: 'Tax1',
+            per_person: true,
+            total: 16.69565217391303,
+            type: 'night',
+            unit: 'percentage',
+            value: 1,
+          },
+          {
+            name: 'Tax2',
+            per_person: true,
+            total: 66.78260869565212,
+            type: 'stay',
+            unit: 'percentage',
+            value: 4,
+          },
+        ],
       },
     },
     'mix of per person & per night & per stay': {
@@ -737,43 +737,43 @@ describe('calculateAmountForEachTax', () => {
         occupancies: [{ adults: 3, children: 1, infants: 0 }],
       },
       expected: {
-        taxesAndFeesTotal: 375,
+        taxesAndFeesTotal: 242,
         taxesAndFeesWithTotalForEach: [
           {
-            name: "Tax3",
+            name: 'Tax3',
             per_person: false,
             total: 40,
-            type: "night",
-            unit: "amount",
+            type: 'night',
+            unit: 'amount',
             value: 10,
           },
           {
-            name: "Tax4",
+            name: 'Tax4',
             per_person: true,
             total: 104,
-            type: "stay",
-            unit: "amount",
+            type: 'stay',
+            unit: 'amount',
             value: 26,
           },
           {
-            name: "Tax1",
+            name: 'Tax1',
             per_person: true,
-            total: 199.9416058394161,
-            type: "night",
-            unit: "percentage",
+            total: 60.601769911504356,
+            type: 'night',
+            unit: 'percentage',
             value: 2,
           },
           {
-            name: "Tax2",
+            name: 'Tax2',
             per_person: false,
-            total: 31.240875912408768,
-            type: "stay",
-            unit: "percentage",
+            total: 37.87610619469022,
+            type: 'stay',
+            unit: 'percentage',
             value: 5,
-          }
-        ]
-      }
-    }
+          },
+        ],
+      },
+    },
   }
 
   for (const key in tests) {
@@ -785,19 +785,19 @@ describe('calculateAmountForEachTax', () => {
   }
 })
 
-describe('calculateAmountForEachTax', () => {
-    it(`should get correct total`, () => {
-      const result = calculateTaxAmount({
-        total: 1000,
-        taxesAndFees: [
-          { name: 'Tax1', unit: 'percentage', type: 'night', per_person: true, value: 2 },
-          { name: 'Tax2', unit: 'percentage', type: 'stay', per_person: false, value: 5 },
-          { name: 'Tax3', unit: 'amount', type: 'night', per_person: false, value: 10 },
-          { name: 'Tax4', unit: 'amount', type: 'stay', per_person: true, value: 26 },
-        ],
-        nights: 4,
-        occupancies: [{ adults: 3, children: 1, infants: 0 }],
-      })
-      expect(result).to.equal(375)
+describe('calculateTaxAmount', () => {
+  it('should get correct total', () => {
+    const result = calculateTaxAmount({
+      total: 1000,
+      taxesAndFees: [
+        { name: 'Tax1', unit: 'percentage', type: 'night', per_person: true, value: 2 },
+        { name: 'Tax2', unit: 'percentage', type: 'stay', per_person: false, value: 5 },
+        { name: 'Tax3', unit: 'amount', type: 'night', per_person: false, value: 10 },
+        { name: 'Tax4', unit: 'amount', type: 'stay', per_person: true, value: 26 },
+      ],
+      nights: 4,
+      occupancies: [{ adults: 3, children: 1, infants: 0 }],
     })
+    expect(result).to.equal(242)
+  })
 })


### PR DESCRIPTION
This is another fix for incorrect tax calculations. Multiplying of nightly percentage taxes is removed.