### PR TITLE
feat(properties): add categories and type, and helper function to match

### DIFF
--- a/compiled/index.js
+++ b/compiled/index.js
@@ -7,5 +7,6 @@ module.exports = {
   currency: require('./currency'),
   occupancy: require('./occupancy'),
   date: require('./date'),
-  calendar: require('./calendar')
+  calendar: require('./calendar'),
+  property: require('./property')
 };

--- a/compiled/property/index.js
+++ b/compiled/property/index.js
@@ -1,0 +1,27 @@
+"use strict";
+
+var HOTEL = ['Hotel', 'Resort', 'Castle', 'Palace', 'Condominium resort', 'Inn', 'Bed & breakfast', 'Guesthouse', 'Lodge', 'Ryokan', 'Tree house property', 'Aparthotel', 'Country House', 'Agritoursm property', 'All-inclusive property', 'Riad'];
+var UNIQUE_STAYS = ['Cabin', 'Chalet', 'Cottage', 'Villa', 'Apartment', 'Private vacation home', 'Houseboat', 'Condominium resort', 'Campsite'];
+var allTypesAndCategories = {
+  HOTEL: HOTEL,
+  UNIQUE_STAYS: UNIQUE_STAYS
+};
+var allCategories = HOTEL.concat(UNIQUE_STAYS);
+
+var defaultTypeForCategory = function defaultTypeForCategory(categoryName) {
+  if (HOTEL.includes(categoryName)) {
+    return 'HOTEL';
+  }
+
+  if (UNIQUE_STAYS.includes(categoryName)) {
+    return 'UNIQUE_STAYS';
+  }
+
+  return null;
+};
+
+module.exports = {
+  defaultTypeForCategory: defaultTypeForCategory,
+  allTypesAndCategories: allTypesAndCategories,
+  allCategories: allCategories
+};

--- a/index.d.ts
+++ b/index.d.ts
@@ -168,4 +168,9 @@ declare module "@luxuryescapes/lib-global" {
       enquiryType: 'customer' | 'admin'
     ) => string;
   };
+  const property: {
+    defaultTypeForCategory: (categoryName: string) => string,
+    allTypesAndCategories: {[type: string]: string},
+    allCategories: Array<string>
+  };
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-global",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "description": "Lib for expanding functionality and deduplicating code between services",
   "main": "compiled/index.js",
   "types": "index.d.ts",

--- a/src/index.js
+++ b/src/index.js
@@ -6,4 +6,5 @@ module.exports = {
   occupancy: require('./occupancy'),
   date: require('./date'),
   calendar: require('./calendar'),
+  property: require('./property'),
 }

--- a/src/property/index.js
+++ b/src/property/index.js
@@ -1,0 +1,49 @@
+const HOTEL = [
+  'Hotel',
+  'Resort',
+  'Castle',
+  'Palace',
+  'Condominium resort',
+  'Inn',
+  'Bed & breakfast',
+  'Guesthouse',
+  'Lodge',
+  'Ryokan',
+  'Tree house property',
+  'Aparthotel',
+  'Country House',
+  'Agritoursm property',
+  'All-inclusive property',
+  'Riad']
+
+const UNIQUE_STAYS = [
+  'Cabin',
+  'Chalet',
+  'Cottage',
+  'Villa',
+  'Apartment',
+  'Private vacation home',
+  'Houseboat',
+  'Condominium resort',
+  'Campsite',
+]
+
+const allTypesAndCategories = { HOTEL, UNIQUE_STAYS }
+
+const allCategories = HOTEL.concat(UNIQUE_STAYS)
+
+const defaultTypeForCategory = (categoryName) => {
+  if (HOTEL.includes(categoryName)) {
+    return 'HOTEL'
+  }
+  if (UNIQUE_STAYS.includes(categoryName)) {
+    return 'UNIQUE_STAYS'
+  }
+  return null
+}
+
+module.exports = {
+  defaultTypeForCategory,
+  allTypesAndCategories,
+  allCategories,
+}

--- a/test/property/index.test.js
+++ b/test/property/index.test.js
@@ -1,0 +1,47 @@
+const chai = require('chai')
+
+const { property } = require('../../compiled')
+
+const expect = chai.expect
+
+describe('Property', () => {
+  beforeEach(() => {
+  })
+
+  afterEach(() => {
+  })
+
+  describe('defaultTypeForCategory', () => {
+    it('Must return a HOTEL type', async() => {
+      const returnData = property.defaultTypeForCategory('Castle')
+
+      expect(returnData).to.eql('HOTEL')
+    })
+
+    it('Must return a UNIQUE_STAYS type', async() => {
+      const returnData = property.defaultTypeForCategory('Houseboat')
+
+      expect(returnData).to.eql('UNIQUE_STAYS')
+    })
+
+    it('Must return a null for unknown category', async() => {
+      const returnData = property.defaultTypeForCategory('blahblahblah')
+
+      expect(returnData).to.eql(null)
+    })
+  })
+
+  describe('allTypesAndCategories', () => {
+    it('Must return a map', async() => {
+      const returnData = property.allTypesAndCategories
+      expect(returnData).to.have.all.keys('HOTEL', 'UNIQUE_STAYS')
+    })
+  })
+
+  describe('allCategories', () => {
+    it('Must return a massive array', async() => {
+      const returnData = property.allCategories
+      expect(returnData).to.have.length(25)
+    })
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -67,6 +67,6 @@
 
     /* Advanced Options */
     "skipLibCheck": false,                           /* Skip type checking of declaration files. */
-    "forceConsistentCasingInFileNames": true        /* Disallow inconsistently-cased references to the same file. */
+    "forceConsistentCasingInFileNames": true         /* Disallow inconsistently-cased references to the same file. */
   }
 }


### PR DESCRIPTION
https://aussiecommerce.atlassian.net/browse/USZ-11
The work being done in both svc-res and svc-bedbank share a common list of property type and category.  To reduce duplication, this list has now been created in lib-global with helpers to manage the mapping