### PR TITLE
feat(properties): added helper to get all types

### DIFF
--- a/compiled/property/index.js
+++ b/compiled/property/index.js
@@ -7,6 +7,7 @@ var allTypesAndCategories = {
   UNIQUE_STAYS: UNIQUE_STAYS
 };
 var allCategories = HOTEL.concat(UNIQUE_STAYS);
+var allTypes = ['HOTEL', 'UNIQUE_STAYS'];
 
 var defaultTypeForCategory = function defaultTypeForCategory(categoryName) {
   if (HOTEL.includes(categoryName)) {
@@ -23,5 +24,6 @@ var defaultTypeForCategory = function defaultTypeForCategory(categoryName) {
 module.exports = {
   defaultTypeForCategory: defaultTypeForCategory,
   allTypesAndCategories: allTypesAndCategories,
-  allCategories: allCategories
+  allCategories: allCategories,
+  allTypes: allTypes
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -169,8 +169,9 @@ declare module "@luxuryescapes/lib-global" {
     ) => string;
   };
   const property: {
-    defaultTypeForCategory: (categoryName: string) => string,
-    allTypesAndCategories: {[type: string]: string},
-    allCategories: Array<string>
+    defaultTypeForCategory: (categoryName: string) => string;
+    allTypesAndCategories: {[type: string]: string};
+    allCategories: Array<string>;
+    allTypes: Array<string>;
   };
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-global",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "description": "Lib for expanding functionality and deduplicating code between services",
   "main": "compiled/index.js",
   "types": "index.d.ts",

--- a/src/property/index.js
+++ b/src/property/index.js
@@ -32,6 +32,8 @@ const allTypesAndCategories = { HOTEL, UNIQUE_STAYS }
 
 const allCategories = HOTEL.concat(UNIQUE_STAYS)
 
+const allTypes = ['HOTEL', 'UNIQUE_STAYS']
+
 const defaultTypeForCategory = (categoryName) => {
   if (HOTEL.includes(categoryName)) {
     return 'HOTEL'
@@ -46,4 +48,5 @@ module.exports = {
   defaultTypeForCategory,
   allTypesAndCategories,
   allCategories,
+  allTypes,
 }

--- a/test/property/index.test.js
+++ b/test/property/index.test.js
@@ -44,4 +44,11 @@ describe('Property', () => {
       expect(returnData).to.have.length(25)
     })
   })
+
+  describe('allTypes', () => {
+    it('Must return all Types', async() => {
+      const returnData = property.allTypes
+      expect(returnData).to.eql(['HOTEL', 'UNIQUE_STAYS'])
+    })
+  })
 })


### PR DESCRIPTION
USZ-11-property-type-category
Missed a useful helper to return just the types, keeping everything isolated here