### PR TITLE
[CONLT-442] Add product type filtering to taxes and fees

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -219,4 +219,11 @@ declare module "@luxuryescapes/lib-global" {
     CAMPSITE: string;
     HOTELSRESORTS: string;
   };
+  const product: {
+    constants: {
+      PRODUCT_ALL: "all",
+      PRODUCT_DYNAMIC: "dynamic",
+      PRODUCT_LTE: "lte",
+    };
+  }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,6 +25,7 @@ declare module "@luxuryescapes/lib-global" {
     currency?: string;
     additional_tax?: boolean;
     excl_flash_at_property?: boolean;
+    product_type?: "all" | "dynamic" | "lte"
   }
 
   interface TaxBreakdown {

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,7 @@ declare module "@luxuryescapes/lib-global" {
     currency?: string;
     additional_tax?: boolean;
     excl_flash_at_property?: boolean;
-    product_type?: "all" | "dynamic" | "lte"
+    product_type?: "all" | "dynamic" | "limited_time_exclusive"
   }
 
   interface TaxBreakdown {
@@ -223,7 +223,7 @@ declare module "@luxuryescapes/lib-global" {
     constants: {
       PRODUCT_ALL: "all",
       PRODUCT_DYNAMIC: "dynamic",
-      PRODUCT_LTE: "lte",
+      PRODUCT_LTE: "limited_time_exclusive",
     };
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "mocha": "^7",
     "mockdate": "^3.0.5",
     "prettier": "^2.3.2",
-    "typescript": "^4.3.5"
+    "typescript": "^4.3.5",
+    "lodash": "4.17.21"
   }
 }

--- a/src/constants/taxesAndFees.ts
+++ b/src/constants/taxesAndFees.ts
@@ -1,0 +1,9 @@
+const PRODUCT_ALL = "all";
+const PRODUCT_DYNAMIC = "dynamic";
+const PRODUCT_LTE = "lte";
+
+module.exports = {
+  PRODUCT_ALL,
+  PRODUCT_DYNAMIC,
+  PRODUCT_LTE,
+};

--- a/src/constants/taxesAndFees.ts
+++ b/src/constants/taxesAndFees.ts
@@ -1,9 +1,0 @@
-const PRODUCT_ALL = "all";
-const PRODUCT_DYNAMIC = "dynamic";
-const PRODUCT_LTE = "lte";
-
-module.exports = {
-  PRODUCT_ALL,
-  PRODUCT_DYNAMIC,
-  PRODUCT_LTE,
-};

--- a/src/index.js
+++ b/src/index.js
@@ -7,4 +7,5 @@ module.exports = {
   date: require('./date'),
   calendar: require('./calendar'),
   property: require('./property'),
+  constants: require('./product'),
 }

--- a/src/offer/pricing.js
+++ b/src/offer/pricing.js
@@ -1,3 +1,6 @@
+import { isEmpty } from 'lodash'
+import * as TAXES_AND_FEES from '../constants/taxesAndFees'
+
 const countOfMembers = (occupancies) => {
   return (
     (occupancies || []).reduce((acc, occupancy) => {
@@ -60,12 +63,26 @@ const calculateTaxAmount = ({ total, taxesAndFees, nights, occupancies, isFlash 
   const commonTaxesAndFees = []
   const propertyTaxesAndFees = []
 
+  const _appendPropertyTaxesAndFees = (taxItem) => {
+    if (!taxItem.payable_at_property || (taxItem.payable_at_property && isFlash && taxItem.excl_flash_at_property)) {
+      commonTaxesAndFees.push(taxItem)
+    } else {
+      propertyTaxesAndFees.push(taxItem)
+    }
+  }
+
   if (taxesAndFees && total) {
     taxesAndFees.forEach((tax) => {
-      if (!tax.payable_at_property || (tax.payable_at_property && isFlash && tax.excl_flash_at_property)) {
-        commonTaxesAndFees.push(tax)
-      } else {
-        propertyTaxesAndFees.push(tax)
+      if (tax.product_type === TAXES_AND_FEES.PRODUCT_DYNAMIC && !isFlash) {
+        _appendPropertyTaxesAndFees(tax)
+      } else if (tax.product_type === TAXES_AND_FEES.PRODUCT_LTE && isFlash) {
+        _appendPropertyTaxesAndFees(tax)
+      } else if (
+        tax.product_type === TAXES_AND_FEES.PRODUCT_ALL ||
+        isEmpty(tax.product_type)
+      ) {
+        // Include if product type is set to ALL or if product type is empty/missing
+        _appendPropertyTaxesAndFees(tax)
       }
     })
 

--- a/src/offer/pricing.js
+++ b/src/offer/pricing.js
@@ -1,5 +1,5 @@
-import { isEmpty } from 'lodash'
-import * as TAXES_AND_FEES from '../constants/taxesAndFees'
+const isEmpty = require('lodash')
+const { PRODUCT_ALL, PRODUCT_DYNAMIC, PRODUCT_LTE } = require('../constants/taxesAndFees')
 
 const countOfMembers = (occupancies) => {
   return (
@@ -73,12 +73,12 @@ const calculateTaxAmount = ({ total, taxesAndFees, nights, occupancies, isFlash 
 
   if (taxesAndFees && total) {
     taxesAndFees.forEach((tax) => {
-      if (tax.product_type === TAXES_AND_FEES.PRODUCT_DYNAMIC && !isFlash) {
+      if (tax.product_type === PRODUCT_DYNAMIC && !isFlash) {
         _appendPropertyTaxesAndFees(tax)
-      } else if (tax.product_type === TAXES_AND_FEES.PRODUCT_LTE && isFlash) {
+      } else if (tax.product_type === PRODUCT_LTE && isFlash) {
         _appendPropertyTaxesAndFees(tax)
       } else if (
-        tax.product_type === TAXES_AND_FEES.PRODUCT_ALL ||
+        tax.product_type === PRODUCT_ALL ||
         isEmpty(tax.product_type)
       ) {
         // Include if product type is set to ALL or if product type is empty/missing

--- a/src/offer/pricing.js
+++ b/src/offer/pricing.js
@@ -1,5 +1,5 @@
 const isEmpty = require('lodash')
-const { PRODUCT_ALL, PRODUCT_DYNAMIC, PRODUCT_LTE } = require('../constants/taxesAndFees')
+const { PRODUCT_ALL, PRODUCT_DYNAMIC, PRODUCT_LTE } = require('../product/constants')
 
 const countOfMembers = (occupancies) => {
   return (

--- a/src/offer/pricing.js
+++ b/src/offer/pricing.js
@@ -71,6 +71,8 @@ const calculateTaxAmount = ({ total, taxesAndFees, nights, occupancies, isFlash 
     }
   }
 
+  // Filter out tax items according to product type and offer type
+  // https://aussiecommerce.atlassian.net/browse/CONLT-442
   if (taxesAndFees && total) {
     taxesAndFees.forEach((tax) => {
       if (tax.product_type === PRODUCT_DYNAMIC && !isFlash) {

--- a/src/offer/pricing.js
+++ b/src/offer/pricing.js
@@ -1,4 +1,4 @@
-const isEmpty = require('lodash')
+const _ = require('lodash')
 const { PRODUCT_ALL, PRODUCT_DYNAMIC, PRODUCT_LTE } = require('../product/constants')
 
 const countOfMembers = (occupancies) => {
@@ -80,8 +80,7 @@ const calculateTaxAmount = ({ total, taxesAndFees, nights, occupancies, isFlash 
       } else if (tax.product_type === PRODUCT_LTE && isFlash) {
         _appendPropertyTaxesAndFees(tax)
       } else if (
-        tax.product_type === PRODUCT_ALL ||
-        isEmpty(tax.product_type)
+        tax.product_type === PRODUCT_ALL || _.isEmpty(tax.product_type)
       ) {
         // Include if product type is set to ALL or if product type is empty/missing
         _appendPropertyTaxesAndFees(tax)

--- a/src/product/constants.js
+++ b/src/product/constants.js
@@ -1,0 +1,9 @@
+const PRODUCT_ALL = 'all'
+const PRODUCT_DYNAMIC = 'dynamic'
+const PRODUCT_LTE = 'lte'
+
+module.exports = {
+  PRODUCT_ALL,
+  PRODUCT_DYNAMIC,
+  PRODUCT_LTE,
+}

--- a/src/product/constants.js
+++ b/src/product/constants.js
@@ -1,6 +1,6 @@
 const PRODUCT_ALL = 'all'
 const PRODUCT_DYNAMIC = 'dynamic'
-const PRODUCT_LTE = 'lte'
+const PRODUCT_LTE = 'limited_time_exclusive'
 
 module.exports = {
   PRODUCT_ALL,

--- a/src/product/index.js
+++ b/src/product/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  taxesAndFees: require('./constants'),
+}

--- a/test/offer/pricing.test.js
+++ b/test/offer/pricing.test.js
@@ -1535,4 +1535,40 @@ describe('calculateTaxAmount', () => {
     })
     expect(result).to.deep.equal({ taxesAndFees: 242, propertyFees: 80 })
   })
+
+  it('should ignore filtered tax items', () => {
+    const result = calculateTaxAmount({
+      total: 1000,
+      taxesAndFees: [
+        {
+          name: 'Tax1',
+          unit: 'percentage',
+          type: 'night',
+          per_person: true,
+          value: 2,
+          product_type: 'limited_time_exclusive',
+        },
+        {
+          name: 'tax2 - should not be added to calculation',
+          unit: 'percentage',
+          type: 'night',
+          per_person: true,
+          value: 2,
+          product_type: 'dynamic',
+        },
+        {
+          name: 'tax3 - missing product type, added to calculation',
+          unit: 'percentage',
+          type: 'night',
+          per_person: true,
+          value: 2,
+          product_type: '',
+        },
+      ],
+      nights: 4,
+      occupancies: [{ adults: 3, children: 1, infants: 0 }],
+      isFlash: true,
+    })
+    expect(result).to.deep.equal({ taxesAndFees: 137, propertyFees: 0 })
+  })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2771,7 +2771,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
-lodash@^4.17.15:
+lodash@4.17.21, lodash@^4.17.15:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
https://aussiecommerce.atlassian.net/browse/CONLT-442

Filter tax items according to their product and offer types:

Dynamic product items should only calculate for: LPC and LME
LTE product items should only calculate for LTLE -> hotel
All product items calculates for all.