### PR TITLE
fix(occupancy): move required occupancy to it's own matcher

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -99,6 +99,7 @@ declare module "@luxuryescapes/lib-global" {
     match: (occupancy: string) => boolean;
     toString: (occupancy: Occupants) => string;
     strummerMatcher: { match: <V>(path?: string, value?: V) => string | undefined, toJSONSchema: () => JSONSchema };
+    strummerMatcherRequired: { match: <V>(path?: string, value?: V) => string | undefined, toJSONSchema: () => JSONSchema };
   };
   const currency: {
     addDollarType: (

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-global",
-  "version": "2.8.7",
+  "version": "2.9.0",
   "description": "Lib for expanding functionality and deduplicating code between services",
   "main": "compiled/index.js",
   "types": "index.d.ts",

--- a/src/occupancy/index.js
+++ b/src/occupancy/index.js
@@ -54,25 +54,30 @@ const get = occupancy => {
   return occupancies
 }
 
-const strummerMatcher = {
-  match: (path, value) => {
-    let dataCheck = value
-    if (typeof value === 'string' && value) {
-      if (value.split(',').every(occupancy => !!occupancy.match(/^[0-9]{1,2}-[0-9]{1,2}-[0-9]{1,2}?$/gi))) {
-        dataCheck = [value.split(',')].flat()
-      } else {
-        dataCheck = [value]
+const getStrummerMatcher = (required = false) => {
+  return {
+    match: (path, value) => {
+      let dataCheck = value
+      if (typeof value === 'string' && value) {
+        if (value.split(',').every(occupancy => !!occupancy.match(/^[0-9]{1,2}-[0-9]{1,2}-[0-9]{1,2}?$/gi))) {
+          dataCheck = [value.split(',')].flat()
+        } else {
+          dataCheck = [value]
+        }
+      } else if (typeof value === 'undefined' || !value) {
+        if (required === true) {
+          return 'Occupancy is required'
+        }
+        dataCheck = []
       }
-    } else if (typeof value === 'undefined' || !value) {
-      return 'Occupancy is required'
-    }
-    for (const occupancy of dataCheck) {
-      if (!match(occupancy)) {
-        return 'Invalid occupancy format'
+      for (const occupancy of dataCheck) {
+        if (!match(occupancy)) {
+          return 'Invalid occupancy format'
+        }
       }
-    }
-  },
-  toJSONSchema: () => ({ type: 'string', properties: {} }),
+    },
+    toJSONSchema: () => ({ type: 'string', properties: {} }),
+  }
 }
 
 module.exports = {
@@ -80,5 +85,6 @@ module.exports = {
   get: get,
   match: match,
   toString: toString,
-  strummerMatcher: strummerMatcher,
+  strummerMatcher: getStrummerMatcher(),
+  strummerMatcherRequired: getStrummerMatcher(true),
 }

--- a/test/occupancy/index.test.js
+++ b/test/occupancy/index.test.js
@@ -82,8 +82,8 @@ describe('Occupancy', () => {
         expect(occupancy.strummerMatcher.match('', '2')).to.eql(undefined)
       })
 
-      it('occupancy is required', () => {
-        expect(occupancy.strummerMatcher.match('', '')).to.eql('Occupancy is required')
+      it('occupancy is not required', () => {
+        expect(occupancy.strummerMatcher.match('', '')).to.eql(undefined)
       })
 
       it('allows multiple occupancies', () => {
@@ -96,6 +96,28 @@ describe('Occupancy', () => {
 
       it('detects an invalid occupancy in an array', () => {
         expect(occupancy.strummerMatcher.match('', ['2', 'x', '3-1'])).to.eql('Invalid occupancy format')
+      })
+    })
+
+    describe('occupancy.strummerMatcherRequired', () => {
+      it('allows an valid occupancy', () => {
+        expect(occupancy.strummerMatcherRequired.match('', '2')).to.eql(undefined)
+      })
+
+      it('occupancy is required', () => {
+        expect(occupancy.strummerMatcherRequired.match('', '')).to.eql('Occupancy is required')
+      })
+
+      it('allows multiple occupancies', () => {
+        expect(occupancy.strummerMatcherRequired.match('', ['2', '3-1'])).to.eql(undefined)
+      })
+
+      it('detects an invalid occupancy', () => {
+        expect(occupancy.strummerMatcherRequired.match('', 'x')).to.eql('Invalid occupancy format')
+      })
+
+      it('detects an invalid occupancy in an array', () => {
+        expect(occupancy.strummerMatcherRequired.match('', ['2', 'x', '3-1'])).to.eql('Invalid occupancy format')
       })
     })
   })


### PR DESCRIPTION
Occupancy matcher compatibility was broken, undoing that so it continues to work as expected. Moved required occupancy to a new matcher