### PR TITLE
Refactor and export calculatePackagePrice function for search

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,14 @@
 declare module "@luxuryescapes/lib-global" {
+  interface Price {
+    currency_code: string;
+    price: number;
+    lux_plus_price: number;
+    value: number;
+    nightly_price: number;
+    lux_plus_nightly_price: number;
+    nightly_value: number;
+  }
+
   interface PackageNightOption {
     packageId: string;
     extraNights: number;
@@ -6,15 +16,7 @@ declare module "@luxuryescapes/lib-global" {
     roomRateId: string;
     name: string;
     duration: number;
-    prices: Array<{
-      currency_code: string;
-      price: number;
-      lux_plus_price: number;
-      value: number;
-      nightly_price: number;
-      lux_plus_nightly_price: number;
-      nightly_value: number;
-    }>;
+    prices: Array<Price>;
   }
 
   interface TaxesAndFees {
@@ -118,6 +120,7 @@ declare module "@luxuryescapes/lib-global" {
     };
     flexibleNights: {
       generateAllOptions: (pkg: any) => Array<PackageNightOption>;
+      calculatePackagePrice: (price: any, extraNights: number) => Price
     };
     duration: {
       getCounts: (packages: Array<object>, field: string) => Array<number>;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-global",
-  "version": "4.2.3",
+  "version": "4.2.4",
   "description": "Lib for expanding functionality and deduplicating code between services",
   "main": "compiled/index.js",
   "types": "index.d.ts",

--- a/src/offer/flexiNights.js
+++ b/src/offer/flexiNights.js
@@ -1,3 +1,32 @@
+function calculatePackagePrice(price, extraNights) {
+  if (extraNights === 0) {
+    return {
+      ...price,
+      currency_code: price.currency_code,
+      price: price.price,
+      lux_plus_price: price.lux_plus_price ?? 0,
+      value: price.value,
+      nightly_price: price.nightly_price,
+      lux_plus_nightly_price: price.lux_plus_nightly_price ?? 0,
+      nightly_value: price.nightly_value,
+    }
+  }
+
+  const hasLuxPlusNightlyPricing = price.lux_plus_price && price.lux_plus_nightly_price
+
+  return {
+    ...price,
+    currency_code: price.currency_code,
+    price: price.price + extraNights * price.nightly_price,
+    // for extra nights, if there's a lux plus price but no lux plus nightly price, final lux plus price will be 0
+    lux_plus_price: hasLuxPlusNightlyPricing ? price.lux_plus_price + extraNights * price.lux_plus_nightly_price : 0,
+    value: price.value + extraNights * price.nightly_value,
+    nightly_price: price.nightly_price,
+    lux_plus_nightly_price: price.lux_plus_nightly_price ?? 0,
+    nightly_value: price.nightly_value,
+  }
+}
+
 /**
  * Calculates the prices based on number of nights and the package prices list
  *
@@ -7,34 +36,7 @@
  */
 function calculatePackagePrices(offerPackagePrices, extraNights = 0) {
   // null comes through, can't use default props for package prices
-  return (offerPackagePrices ?? []).map((price) => {
-    if (extraNights === 0) {
-      return {
-        ...price,
-        currency_code: price.currency_code,
-        price: price.price,
-        lux_plus_price: price.lux_plus_price ?? 0,
-        value: price.value,
-        nightly_price: price.nightly_price,
-        lux_plus_nightly_price: price.lux_plus_nightly_price ?? 0,
-        nightly_value: price.nightly_value,
-      }
-    }
-
-    const hasLuxPlusNightlyPricing = price.lux_plus_price && price.lux_plus_nightly_price
-
-    return {
-      ...price,
-      currency_code: price.currency_code,
-      price: price.price + extraNights * price.nightly_price,
-      // for extra nights, if there's a lux plus price but no lux plus nightly price, final lux plus price will be 0
-      lux_plus_price: hasLuxPlusNightlyPricing ? price.lux_plus_price + extraNights * price.lux_plus_nightly_price : 0,
-      value: price.value + extraNights * price.nightly_value,
-      nightly_price: price.nightly_price,
-      lux_plus_nightly_price: price.lux_plus_nightly_price ?? 0,
-      nightly_value: price.nightly_value,
-    }
-  })
+  return (offerPackagePrices ?? []).map((price) => calculatePackagePrice(price, extraNights))
 }
 
 /**
@@ -81,4 +83,5 @@ function generateAllOptions(pkg) {
 
 module.exports = {
   generateAllOptions,
+  calculatePackagePrice,
 }


### PR DESCRIPTION
Minor refactor and export a function so svc-search can use it. Svc-search can't use the generateAllOptions because it doesn't need to generate every single option. It just needs the logical to calculate the price for extra nights.