### PR TITLE
[OPEX-1847]: tenantFromBrand dedupe

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -300,5 +300,6 @@ declare module "@luxuryescapes/lib-global" {
         }
       }
     }
+    tenantFromBrand: (brand: string | null | undefined) => string;
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-global",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "description": "Lib for expanding functionality and deduplicating code between services",
   "main": "compiled/index.js",
   "types": "index.d.ts",

--- a/src/white-label/index.js
+++ b/src/white-label/index.js
@@ -1,4 +1,5 @@
 
 module.exports = {
   dynamicTags: require('./dynamic-tags'),
+  tenantFromBrand: require('./tenant-from-brand'),
 }

--- a/src/white-label/tenant-from-brand.js
+++ b/src/white-label/tenant-from-brand.js
@@ -1,0 +1,31 @@
+const tenantFromBrand = (brand) => {
+  switch (brand) {
+    case 'cudo':
+    case 'cudotravel':
+    case 'treatme':
+    case 'treatmetravel':
+    case 'deals':
+    case 'dealstravel':
+    case 'lebusinesstraveller':
+      return 'lux'
+    case 'scoopontravel':
+    case 'scooponexperience':
+    case 'scoopon':
+      return 'scoopon'
+    case 'ledvendor':
+    case 'led_admin':
+      return 'led_admin'
+    case 'yidu':
+      return 'yidu'
+    case 'zoomzoom':
+      return 'zoomzoom'
+    case 'kogantravel':
+      return 'kogantravel'
+    case 'leagenthub':
+      return 'leagenthub'
+    default:
+      return 'lux'
+  }
+}
+
+module.exports = tenantFromBrand

--- a/test/white-label/tenant-from-brand.test.js
+++ b/test/white-label/tenant-from-brand.test.js
@@ -46,12 +46,4 @@ describe('tenantFromBrand', () => {
     ]
     expect(args.every((a) => tenantFromBrand(a) === 'lux')).to.eql(true)
   })
-
-  it("should return 'lux' when the argument is undefined", () => {
-    expect(tenantFromBrand(undefined)).to.eql('lux')
-  })
-
-  it("should return 'lux' when the argument is null", () => {
-    expect(tenantFromBrand(null)).to.eql('lux')
-  })
 })

--- a/test/white-label/tenant-from-brand.test.js
+++ b/test/white-label/tenant-from-brand.test.js
@@ -1,0 +1,57 @@
+const { expect } = require('chai')
+const tenantFromBrand = require('../../src/white-label/tenant-from-brand')
+
+describe('tenantFromBrand', () => {
+  it("should return 'lux' for specific arguments", () => {
+    const args = [
+      'cudo', 'cudotravel', 'treatme', 'treatmetravel',
+      'deals', 'dealstravel', 'lebusinesstraveller', 'lux',
+    ]
+    expect(args.every((a) => tenantFromBrand(a) === 'lux')).to.eql(true)
+  })
+
+  it("should return 'scoopon' for specific arguments", () => {
+    const args = [
+      'scoopontravel', 'scooponexperience', 'scoopon',
+    ]
+    expect(args.every((a) => tenantFromBrand(a) === 'scoopon')).to.eql(true)
+  })
+
+  it("should return 'led_admin' for specific arguments", () => {
+    const args = [
+      'ledvendor', 'led_admin',
+    ]
+    expect(args.every((a) => tenantFromBrand(a) === 'led_admin')).to.eql(true)
+  })
+
+  it("should return 'yidu' when given 'yidu' as an argument", () => {
+    expect(tenantFromBrand('yidu')).to.eql('yidu')
+  })
+
+  it("should return 'zoomzoom' when given 'zoomzoom' as an argument", () => {
+    expect(tenantFromBrand('yidu')).to.eql('yidu')
+  })
+
+  it("should return 'kogantravel' when given 'kogantravel' as an argument", () => {
+    expect(tenantFromBrand('kogantravel')).to.eql('kogantravel')
+  })
+
+  it("should return 'leagenthub' when given 'leagenthub' as an argument", () => {
+    expect(tenantFromBrand('leagenthub')).to.eql('leagenthub')
+  })
+
+  it("should return 'lux' for unrecognized arguments or brands", () => {
+    const args = [
+      'test', 'foo', 'bar', undefined, null,
+    ]
+    expect(args.every((a) => tenantFromBrand(a) === 'lux')).to.eql(true)
+  })
+
+  it("should return 'lux' when the argument is undefined", () => {
+    expect(tenantFromBrand(undefined)).to.eql('lux')
+  })
+
+  it("should return 'lux' when the argument is null", () => {
+    expect(tenantFromBrand(null)).to.eql('lux')
+  })
+})


### PR DESCRIPTION
## Story tracking
[Jira ticket](https://aussiecommerce.atlassian.net/browse/OPEX-1847)
[svc-order PR feedback this work stems from](https://github.com/lux-group/svc-order/pull/3369#discussion_r1625384266)

## Summary of changes
There exists a `tenantFromBrand` function used in both `svc-order` and `svc-auth`. The aim of this function is determine the correct name of a tenant from a given brand name. This PR aims to dedupe this piece of logic by adding it to this library, and then imported where it needs to be used.