### PR TITLE
fix!: environment export does not match index.d.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-global",
-  "version": "4.2.7",
+  "version": "5.0.0",
   "description": "Lib for expanding functionality and deduplicating code between services",
   "main": "compiled/index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-global",
-  "version": "4.3.0",
+  "version": "5.0.0",
   "description": "Lib for expanding functionality and deduplicating code between services",
   "main": "compiled/index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-global",
-  "version": "5.0.0",
+  "version": "4.3.0",
   "description": "Lib for expanding functionality and deduplicating code between services",
   "main": "compiled/index.js",
   "types": "index.d.ts",

--- a/src/environment/index.js
+++ b/src/environment/index.js
@@ -6,7 +6,7 @@ const environment = {
   PERFORMANCE: 'performance',
 }
 
-export default {
+module.exports = {
   ...environment,
   // @deprecated kept for backward compability, not supported by index.d.ts
   environment,

--- a/src/environment/index.js
+++ b/src/environment/index.js
@@ -1,7 +1,13 @@
-module.exports = {
+const environment = {
   DEVELOPMENT: 'development',
   SPEC: 'spec',
   TEST: 'test',
   PRODUCTION: 'production',
   PERFORMANCE: 'performance',
+}
+
+export default {
+  ...environment,
+  // @deprecated kept for backward compability, not supported by index.d.ts
+  environment,
 }

--- a/src/environment/index.js
+++ b/src/environment/index.js
@@ -1,4 +1,4 @@
-export const environment = {
+module.exports = {
   DEVELOPMENT: 'development',
   SPEC: 'spec',
   TEST: 'test',

--- a/src/environment/index.js
+++ b/src/environment/index.js
@@ -6,8 +6,4 @@ const environment = {
   PERFORMANCE: 'performance',
 }
 
-module.exports = {
-  ...environment,
-  // @deprecated kept for backward compability, not supported by index.d.ts
-  environment,
-}
+module.exports = environment

--- a/test/environment/index.test.js
+++ b/test/environment/index.test.js
@@ -1,0 +1,11 @@
+const chai = require('chai')
+
+const { environment } = require('../../compiled')
+
+const expect = chai.expect
+
+describe('Environment', () => {
+    it('should work', () => {
+        expect(environment.PRODUCTION).to.eql('production')
+    })
+})


### PR DESCRIPTION
with how we exported the `environment` object before, clients had to do:

```
import { environment } from "lib/global"

console.log(environment.environment.PRODUCTION)
```
to get the "production" string. However, this wasn't caught because index.d.ts indicates that this is the proper import (and how clients use them currently):

```
import { environment } from "lib/global"

console.log(environment.PRODUCTION)
```

This means that anywhere `environment.PRODUCTION` is being used, it's evaluated to undefined on runtime. This PR introduce a breaking change that corrects the export and align it with index.d.ts definition.