### PR TITLE
fix(occupants): HP-625: update occupants schema

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -50,7 +50,7 @@ declare module "@luxuryescapes/lib-global" {
     adults: number;
     children?: number;
     infants?: number;
-    childrenAge?: Array<number>;
+    childrenAges?: Array<number>;
   }
 
   interface RoomIncludedGuests {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-global",
-  "version": "5.1.4",
+  "version": "6.1.4",
   "description": "Lib for expanding functionality and deduplicating code between services",
   "main": "compiled/index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-global",
-  "version": "6.1.4",
+  "version": "6.0.0",
   "description": "Lib for expanding functionality and deduplicating code between services",
   "main": "compiled/index.js",
   "types": "index.d.ts",

--- a/src/offer/pricing.js
+++ b/src/offer/pricing.js
@@ -48,7 +48,7 @@ const getTaxTotal = ({ type, unit, value, nights, perPerson, occupancies }) => {
  *   adults: number;
  *   children?: number;
  *   infants?: number;
- *   childrenAge?: Array<number>;
+ *   childrenAges?: Array<number>;
  * }
  *
  * @param {object} params - All params


### PR DESCRIPTION
Type mismatch between the exposed type `childrenAge` and the implementation using `childrenAges`

Update Occupancts type schema to use plural `childrenAges` (to match the impl)
https://github.com/lux-group/lib-global/blob/e9d03d3723f18c41125d5e4d9032f1c0e588b82f/src/occupancy/index.js#L21
(we could also change the impl but either way it will break other repos as some are ignoring the type and using `childrenAges`, so we stick with the majority of our repos using plural and keep the naming convention consistent)

Repos needing review and potential update
https://github.com/search?q=org%3Alux-group+lib-global+occupancy&type=code