### PR TITLE
[HC-379] - fix: prevent extra guest surchages

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -58,7 +58,7 @@ declare module "@luxuryescapes/lib-global" {
     adults: number;
     children: number;
     infants: number;
-    teenagers: number;
+    teenagers?: number;
   }
 
   interface RoomExtraGuestSurcharge {
@@ -68,7 +68,7 @@ declare module "@luxuryescapes/lib-global" {
     child_cost?: number;
     infant_amount: number;
     infant_cost?: number;
-    teenager_amount: number;
+    teenager_amount?: number;
     teenager_cost?: number;
     currency?: string;
   }
@@ -272,7 +272,7 @@ declare module "@luxuryescapes/lib-global" {
     ULTRA_LUX: string;
     HOTELSRESORTS: string;
     extraGuests: {
-      get: ({ adults, children, infants, teenagers, includedGuests }: { adults: number, children: number, infants: number, teenagers: number, includedGuests: RoomIncludedGuests[] }) => RoomIncludedGuests[];
+      get: ({ adults, children, infants, teenagers, includedGuests }: { adults: number, children: number, infants: number, teenagers?: number, includedGuests: RoomIncludedGuests[] }) => RoomIncludedGuests[];
       surcharges: ({ nights, extraGuests, extraGuestSurcharge }: { nights: number, extraGuests: RoomIncludedGuests[][], extraGuestSurcharge?: RoomExtraGuestSurcharge }) => ExtraGuestSurcharge;
     }
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-global",
-  "version": "6.0.4",
+  "version": "6.1.0",
   "description": "Lib for expanding functionality and deduplicating code between services",
   "main": "compiled/index.js",
   "types": "index.d.ts",

--- a/src/property/extraGuests.js
+++ b/src/property/extraGuests.js
@@ -4,7 +4,7 @@ function floatify(value) {
   return parseFloat(parseFloat(value).toFixed(2))
 }
 
-function get({ adults, children, infants, teenagers, includedGuests }) {
+function get({ adults, children, infants, teenagers = 0, includedGuests }) {
   if (!adults && !children && !infants && !teenagers) {
     return []
   }
@@ -14,7 +14,14 @@ function get({ adults, children, infants, teenagers, includedGuests }) {
     return []
   }
 
-  const validIncludedGuests = includedGuests.filter(
+  const normalizedIncludedGuests = includedGuests.map((included) => ({
+    adults: included.adults || 0,
+    children: included.children || 0,
+    infants: included.infants || 0,
+    teenagers: included.teenagers || 0,
+  }))
+
+  const validIncludedGuests = normalizedIncludedGuests.filter(
     (included) =>
       adults <= included.adults &&
       children <= included.children &&
@@ -25,7 +32,7 @@ function get({ adults, children, infants, teenagers, includedGuests }) {
     return []
   }
 
-  return includedGuests.map((included) => ({
+  return normalizedIncludedGuests.map((included) => ({
     adults: Math.max(adults - included.adults, 0),
     children: Math.max(children - included.children, 0),
     infants: Math.max(infants - included.infants, 0),
@@ -85,7 +92,7 @@ function surcharges({
         }
       }
 
-      if (extra.teenagers) {
+      if (extra.teenagers && 'teenager_amount' in extraGuestSurcharge) {
         perNightAmounts.sell += extra.teenagers * extraGuestSurcharge.teenager_amount
         if (!isUndefined(extraGuestSurcharge.teenager_cost)) {
           perNightAmounts.cost += extra.teenagers * extraGuestSurcharge.teenager_cost

--- a/test/property/extraGuests.test.js
+++ b/test/property/extraGuests.test.js
@@ -103,7 +103,7 @@ describe('property = extraGuests', function() {
       ])
     })
 
-    it('should work with old format (no teenagers)', () => {
+    it('should be backwards compatible with old format (no teenagers)', () => {
       const params = {
         adults: 2,
         children: 1,

--- a/test/property/extraGuests.test.js
+++ b/test/property/extraGuests.test.js
@@ -352,7 +352,7 @@ describe('property = extraGuests', function() {
   })
 
   describe('integration', function() {
-    it('extraGuests integration with surcharges (no teenagers)', () => {
+    it('should calculate surcharges with no teenagers', () => {
       const nights = 3
       const occupancies = [
         { adults: 3, children: 1, infants: 1 },
@@ -447,6 +447,54 @@ describe('property = extraGuests', function() {
           applies: true,
           cost: 525,
           sell: 600,
+        },
+      })
+    })
+
+    it('should not include surcharges if extraGuests is empty', () => {
+      const nights = 3
+      const occupancies = [
+        { adults: 2, children: 1, infants: 1 },
+      ]
+
+      const includedGuestsByRate = [
+        { adults: 2, children: 1, infants: 1 },
+      ]
+
+      const extraGuestSurcharge = {
+        currency: 'AUD',
+        adult_cost: 100,
+        adult_amount: 120,
+        child_cost: 50,
+        child_amount: 60,
+        infant_cost: 10,
+        infant_amount: 12,
+      }
+
+      const extraGuests = occupancies.map((occupancy) =>
+        property.extraGuests.get({
+          adults: occupancy.adults,
+          children: occupancy.children,
+          infants: occupancy.infants,
+          includedGuests: includedGuestsByRate,
+        }),
+      )
+
+      const result = property.extraGuests.surcharges({
+        nights,
+        extraGuests,
+        extraGuestSurcharge,
+      })
+
+      expect(result).to.eql({
+        applies: false,
+        cost: 0,
+        sell: 0,
+        costCurrency: undefined,
+        duration: {
+          applies: false,
+          cost: 0,
+          sell: 0,
         },
       })
     })

--- a/test/property/extraGuests.test.js
+++ b/test/property/extraGuests.test.js
@@ -8,12 +8,10 @@ const buildParams = (opts = {}) => ({
   adults: 2,
   children: 1,
   infants: 0,
-  teenagers: 0,
   includedGuests: [{
     adults: 2,
     children: 1,
     infants: 0,
-    teenagers: 0,
   }],
   ...opts,
 })
@@ -35,7 +33,7 @@ describe('property = extraGuests', function() {
         adults: 3,
         children: 0,
         infants: 0,
-        includedGuests: [{ adults: 3, children: 0, infants: 0, teenagers: 0 }],
+        includedGuests: [{ adults: 3, children: 0, infants: 0 }],
       })
       expect(property.extraGuests.get(params)).to.eql([])
     })
@@ -45,9 +43,8 @@ describe('property = extraGuests', function() {
         adults: 3,
         children: 2,
         infants: 1,
-        teenagers: 0,
         includedGuests: [
-          { adults: 1, children: 2, infants: 0, teenagers: 0 },
+          { adults: 1, children: 2, infants: 0 },
         ],
       })
       expect(property.extraGuests.get(params)).to.eql([
@@ -55,7 +52,6 @@ describe('property = extraGuests', function() {
           adults: 2,
           children: 0,
           infants: 1,
-          teenagers: 0,
         },
       ])
     })
@@ -65,10 +61,9 @@ describe('property = extraGuests', function() {
         adults: 1,
         children: 2,
         infants: 0,
-        teenagers: 0,
         includedGuests: [
-          { adults: 2, children: 0, infants: 1, teenagers: 0 },
-          { adults: 1, children: 1, infants: 1, teenagers: 0 },
+          { adults: 2, children: 0, infants: 1 },
+          { adults: 1, children: 1, infants: 1 },
         ],
       })
       expect(property.extraGuests.get(params)).to.eql([
@@ -76,13 +71,11 @@ describe('property = extraGuests', function() {
           adults: 0,
           children: 2,
           infants: 0,
-          teenagers: 0,
         },
         {
           adults: 0,
           children: 1,
           infants: 0,
-          teenagers: 0,
         },
       ])
     })
@@ -105,6 +98,24 @@ describe('property = extraGuests', function() {
           teenagers: 1,
         },
       ])
+    })
+
+    it('should work with old format (no teenagers)', () => {
+      const params = {
+        adults: 2,
+        children: 1,
+        infants: 0,
+        includedGuests: [{
+          adults: 1,
+          children: 1,
+          infants: 0,
+        }],
+      }
+      expect(property.extraGuests.get(params)).to.eql([{
+        adults: 1,
+        children: 0,
+        infants: 0,
+      }])
     })
   })
 
@@ -282,6 +293,35 @@ describe('property = extraGuests', function() {
           sell: 704,
         },
         sell: 352,
+      })
+    })
+
+    it('should calculate surcharges without teenager fields', () => {
+      const params = {
+        nights: 2,
+        extraGuests: [[{ adults: 1, children: 1, infants: 1 }]],
+        extraGuestSurcharge: {
+          currency: 'AUD',
+          adult_cost: 111,
+          adult_amount: 120,
+          child_cost: 50,
+          child_amount: 60,
+          infant_cost: 10,
+          infant_amount: 12,
+          // No teenager_amount or teenager_cost
+        },
+      }
+      const result = property.extraGuests.surcharges(params)
+      expect(result).to.eql({
+        applies: true,
+        cost: 171, // Only adult + child + infant costs
+        costCurrency: 'AUD',
+        duration: {
+          applies: true,
+          cost: 342,
+          sell: 384, // Only adult + child + infant amounts
+        },
+        sell: 192,
       })
     })
   })


### PR DESCRIPTION
Fixed a bug where surcharges were incorrectly being applied when guest counts contained invalid values. The issue occurred when calculating extra guests with invalid teenager counts, causing the system to treat empty guest configurations
as having extra guests.

- Invalid guest counts are properly handled
- Added normalization of includedGuests to get function inside extraGuests